### PR TITLE
feat(v2): Design System + Framer Motion — PR1 e PR2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/app/globals.css
+++ b/app/globals.css
@@ -71,16 +71,15 @@
   /* Transições */
   --ease-ui:     180ms cubic-bezier(0.16, 1, 0.3, 1);
   --ease-bounce: 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
-  /* alias legado */
   --ease-out:    180ms cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in:     180ms cubic-bezier(0.4, 0, 1, 1);
   --duration:    180ms;
 
-  /* Sombras — nomenclatura semântica */
+  /* Sombras */
   --shadow-sm:   0 1px 3px rgba(0, 0, 0, 0.4);
   --shadow-md:   0 4px 16px rgba(0, 0, 0, 0.5);
   --shadow-lg:   0 12px 40px rgba(0, 0, 0, 0.6);
   --shadow-gold: 0 0 20px rgba(200, 168, 75, 0.18);
-  /* aliases legado */
   --shadow-card:  0 4px 20px rgba(0, 0, 0, 0.45);
   --shadow-hover: 0 8px 32px rgba(0, 0, 0, 0.65);
 
@@ -186,10 +185,9 @@ p, li { text-wrap: pretty; max-width: 72ch; }
     box-shadow: var(--shadow-sm);
     border-color: var(--border-gold);
   }
-  /* Alias legado */
   .card-lol { @apply card; background: var(--surface-3); }
 
-  /* ── Botões — sistema unificado ── */
+  /* ── Botões ── */
   .btn {
     @apply inline-flex items-center justify-center gap-2 font-semibold;
     font-family: var(--font-display);
@@ -228,7 +226,6 @@ p, li { text-wrap: pretty; max-width: 72ch; }
 
   .btn-sm { padding: 6px 14px; font-size: var(--text-xs); }
 
-  /* Aliases legado */
   .btn-gold         { @apply btn-primary; }
   .btn-outline-gold { @apply btn-ghost; }
 
@@ -266,24 +263,11 @@ p, li { text-wrap: pretty; max-width: 72ch; }
     color: var(--gold);
     border: 1px solid rgba(200, 168, 75, 0.25);
   }
-  .badge-win {
-    @apply badge;
-    background: var(--win-dim);
-    color: var(--win);
-  }
-  .badge-loss {
-    @apply badge;
-    background: var(--loss-dim);
-    color: var(--loss);
-  }
-  .badge-blue {
-    @apply badge;
-    background: var(--blue-dim);
-    color: var(--blue-accent);
-  }
+  .badge-win  { @apply badge; background: var(--win-dim);  color: var(--win); }
+  .badge-loss { @apply badge; background: var(--loss-dim); color: var(--loss); }
+  .badge-blue { @apply badge; background: var(--blue-dim); color: var(--blue-accent); }
   .badge-tier { @apply badge; }
 
-  /* Aliases legado */
   .stat-pill  { @apply badge-gold; }
   .tag-win    { @apply badge-win; }
   .tag-loss   { @apply badge-loss; }
@@ -322,6 +306,20 @@ p, li { text-wrap: pretty; max-width: 72ch; }
   }
 
   /* ── Match row highlight ── */
-  .row-win  { background: linear-gradient(90deg, var(--win-dim) 0%, transparent 60%); }
+  .row-win  { background: linear-gradient(90deg, var(--win-dim)  0%, transparent 60%); }
   .row-loss { background: linear-gradient(90deg, var(--loss-dim) 0%, transparent 60%); }
+
+  /* ── Mastery card ── */
+  .mastery-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--sp-1);
+    background: rgba(10, 20, 40, 0.7);
+    border-radius: var(--radius-md);
+    padding: 10px 10px 8px;
+    min-width: 76px;
+    transition: transform 200ms var(--ease-out), border-color 200ms var(--ease-out);
+  }
+  .mastery-card:hover { transform: scale(1.05); }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,5 @@
 /* ── Fontes — DEVE ser o primeiro statement antes dos @tailwind ─────── */
-@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@300;400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@300;400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -8,80 +8,96 @@
 /* ── Design Tokens — ArenaGG Dark Theme ─────────────────────────────── */
 :root {
   /* Superfícies */
-  --bg:           #050D1A;
-  --surface:      #0A1428;
-  --surface-2:    #112240;
-  --surface-3:    #162b4d;
+  --bg:              #050D1A;
+  --surface:         #0A1428;
+  --surface-2:       #0D1B34;
+  --surface-3:       #112240;
+  --surface-offset:  #152845;
 
   /* Bordas */
-  --border:       rgba(30,58,95,0.9);
-  --border-soft:  rgba(30,58,95,0.45);
-  --border-gold:  rgba(200,168,75,0.3);
+  --border:          rgba(30, 58, 95, 0.9);
+  --border-soft:     rgba(30, 58, 95, 0.45);
+  --border-gold:     rgba(200, 168, 75, 0.3);
 
   /* Paleta de cor */
-  --gold:         #C8A84B;
-  --gold-hover:   #E8D48B;
-  --gold-dim:     rgba(200,168,75,0.15);
-  --blue-lol:     #0BC4E3;
-  --win:          #22C55E;
-  --win-dim:      rgba(34,197,94,0.12);
-  --loss:         #EF4444;
-  --loss-dim:     rgba(239,68,68,0.12);
+  --gold:            #C8A84B;
+  --gold-hover:      #E8D48B;
+  --gold-dim:        rgba(200, 168, 75, 0.12);
+  --blue-lol:        #0BC4E3;
+  --blue-accent:     #3B82F6;
+  --blue-dim:        rgba(59, 130, 246, 0.12);
+  --win:             #22C55E;
+  --win-dim:         rgba(34, 197, 94, 0.12);
+  --loss:            #EF4444;
+  --loss-dim:        rgba(239, 68, 68, 0.12);
 
   /* Texto */
-  --text:         #F1F5F9;
-  --text-muted:   #94A3B8;
-  --text-faint:   #4B5563;
-  --text-inverse: #050D1A;
+  --text:            #F1F5F9;
+  --text-muted:      #94A3B8;
+  --text-faint:      #4B6380;
+  --text-inverse:    #050D1A;
 
   /* Tipografia */
-  --font-display: 'Sora', 'Inter', sans-serif;
-  --font-body:    'Inter', sans-serif;
+  --font-display:    'Sora', 'Segoe UI', sans-serif;
+  --font-body:       'Inter', 'Segoe UI', sans-serif;
 
   /* Escala fluida */
-  --text-xs:   clamp(0.75rem,  0.7rem  + 0.25vw, 0.875rem);
-  --text-sm:   clamp(0.875rem, 0.8rem  + 0.35vw, 1rem);
-  --text-base: clamp(1rem,     0.95rem + 0.25vw, 1.125rem);
-  --text-lg:   clamp(1.125rem, 1rem    + 0.75vw, 1.5rem);
-  --text-xl:   clamp(1.5rem,   1.2rem  + 1.25vw, 2.25rem);
-  --text-2xl:  clamp(2rem,     1.2rem  + 2.5vw,  3.5rem);
+  --text-xs:    clamp(0.75rem,  0.70rem + 0.25vw, 0.875rem);
+  --text-sm:    clamp(0.875rem, 0.80rem + 0.35vw, 1rem);
+  --text-base:  clamp(1rem,     0.95rem + 0.25vw, 1.125rem);
+  --text-lg:    clamp(1.125rem, 1.00rem + 0.75vw, 1.5rem);
+  --text-xl:    clamp(1.5rem,   1.20rem + 1.25vw, 2.25rem);
+  --text-2xl:   clamp(2rem,     1.20rem + 2.50vw, 3.5rem);
 
-  /* Espaçamento 4px */
-  --sp-1:  0.25rem;
-  --sp-2:  0.5rem;
-  --sp-3:  0.75rem;
-  --sp-4:  1rem;
-  --sp-6:  1.5rem;
-  --sp-8:  2rem;
-  --sp-12: 3rem;
-  --sp-16: 4rem;
+  /* Espaçamento 4px — escala completa */
+  --sp-1:  0.25rem;  /*  4px */
+  --sp-2:  0.5rem;   /*  8px */
+  --sp-3:  0.75rem;  /* 12px */
+  --sp-4:  1rem;     /* 16px */
+  --sp-5:  1.25rem;  /* 20px */
+  --sp-6:  1.5rem;   /* 24px */
+  --sp-8:  2rem;     /* 32px */
+  --sp-10: 2.5rem;   /* 40px */
+  --sp-12: 3rem;     /* 48px */
+  --sp-16: 4rem;     /* 64px */
 
   /* Radius */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
-  --radius-xl: 20px;
+  --radius-sm:   6px;
+  --radius-md:   10px;
+  --radius-lg:   14px;
+  --radius-xl:   20px;
   --radius-full: 9999px;
 
-  /* Sombras */
-  --shadow-sm:   0 2px 8px rgba(0,0,0,0.35);
-  --shadow-card: 0 4px 20px rgba(0,0,0,0.45);
-  --shadow-hover:0 8px 32px rgba(0,0,0,0.65);
-  --shadow-gold: 0 0 20px rgba(200,168,75,0.2);
-
   /* Transições */
-  --ease-out:  cubic-bezier(0.16, 1, 0.3, 1);
-  --duration:  180ms;
+  --ease-ui:     180ms cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-bounce: 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* alias legado */
+  --ease-out:    180ms cubic-bezier(0.16, 1, 0.3, 1);
+  --duration:    180ms;
+
+  /* Sombras — nomenclatura semântica */
+  --shadow-sm:   0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md:   0 4px 16px rgba(0, 0, 0, 0.5);
+  --shadow-lg:   0 12px 40px rgba(0, 0, 0, 0.6);
+  --shadow-gold: 0 0 20px rgba(200, 168, 75, 0.18);
+  /* aliases legado */
+  --shadow-card:  0 4px 20px rgba(0, 0, 0, 0.45);
+  --shadow-hover: 0 8px 32px rgba(0, 0, 0, 0.65);
+
+  /* Larguras de conteúdo */
+  --content-narrow:  640px;
+  --content-default: 960px;
+  --content-wide:    1280px;
 }
 
 /* ── Base reset ──────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 html {
-  scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  scroll-behavior: smooth;
   scroll-padding-top: var(--sp-16);
 }
 
@@ -96,11 +112,15 @@ body {
 
 img, picture, video, canvas, svg { display: block; max-width: 100%; height: auto; }
 input, button, textarea, select { font: inherit; color: inherit; }
-h1,h2,h3,h4,h5,h6 { text-wrap: balance; line-height: 1.2; font-family: var(--font-display); }
-p, li { text-wrap: pretty; }
+h1, h2, h3, h4, h5, h6 {
+  text-wrap: balance;
+  line-height: 1.2;
+  font-family: var(--font-display);
+}
+p, li { text-wrap: pretty; max-width: 72ch; }
 
 ::selection {
-  background: rgba(200,168,75,0.28);
+  background: rgba(200, 168, 75, 0.28);
   color: var(--text);
 }
 
@@ -120,174 +140,188 @@ p, li { text-wrap: pretty; }
 }
 
 /* ── Scrollbar ────────────────────────────────────────────────────────── */
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: var(--surface); }
-::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: var(--radius-full); }
-::-webkit-scrollbar-thumb:hover { background: rgba(200,168,75,0.4); }
+::-webkit-scrollbar        { width: 6px; height: 6px; }
+::-webkit-scrollbar-track  { background: var(--surface); }
+::-webkit-scrollbar-thumb  { background: var(--surface-offset); border-radius: var(--radius-full); }
+::-webkit-scrollbar-thumb:hover { background: rgba(200, 168, 75, 0.4); }
 
 /* ── Animações globais ────────────────────────────────────────────────── */
-@keyframes profile-frame-pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.55; }
-}
-@keyframes profile-frame-rotate {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
-}
-@keyframes profile-frame-dash {
-  0%   { stroke-dashoffset: 0; }
-  100% { stroke-dashoffset: -565; }
-}
-@keyframes shimmer {
-  0%   { background-position: -200% 0; }
-  100% { background-position:  200% 0; }
-}
-@keyframes float {
-  0%, 100% { transform: translateY(0px); }
-  50%       { transform: translateY(-6px); }
-}
+@keyframes profile-frame-pulse  { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
+@keyframes profile-frame-rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes profile-frame-dash   { 0% { stroke-dashoffset: 0; } 100% { stroke-dashoffset: -565; } }
+@keyframes shimmer              { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+@keyframes float                { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-6px); } }
+@keyframes fade-in-up           { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes glow-pulse           { 0%, 100% { box-shadow: 0 0 12px rgba(200,168,75,0.2); } 50% { box-shadow: 0 0 28px rgba(200,168,75,0.4); } }
 
 .profile-frame-ring  { animation: profile-frame-pulse 2.4s ease-in-out infinite; }
-.profile-frame-dash  { animation: profile-frame-dash  8s   linear     infinite; }
+.profile-frame-dash  { animation: profile-frame-dash 8s linear infinite; }
 .animate-float       { animation: float 3s ease-in-out infinite; }
-
-/* ── Skeleton loader ─────────────────────────────────────────────────── */
-.skeleton {
-  background: linear-gradient(
-    90deg,
-    var(--surface) 25%,
-    var(--surface-2) 50%,
-    var(--surface) 75%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.5s ease-in-out infinite;
-  border-radius: var(--radius-sm);
-}
+.animate-fade-in-up  { animation: fade-in-up 0.4s var(--ease-ui) both; }
 
 /* ── Componentes ─────────────────────────────────────────────────────── */
 @layer components {
-  /* Card base */
+
+  /* ── Cards ── */
   .card {
-    @apply rounded-2xl border p-6;
-    background: var(--surface);
-    border-color: var(--border);
-    box-shadow: var(--shadow-card);
-    transition: box-shadow var(--duration) var(--ease-out),
-                border-color var(--duration) var(--ease-out),
-                transform var(--duration) var(--ease-out);
-  }
-  .card:hover {
-    box-shadow: var(--shadow-hover);
-    border-color: var(--border-gold);
-  }
-
-  /* Card legado — mantido para compatibilidade */
-  .card-lol {
-    @apply card;
-  }
-
-  /* Botão primário (ouro) */
-  .btn-gold {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--sp-2);
-    background: var(--gold);
-    color: var(--text-inverse);
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: var(--text-sm);
-    padding: 10px 24px;
-    border-radius: var(--radius-md);
-    border: none;
-    cursor: pointer;
-    transition: background var(--duration) var(--ease-out),
-                transform 100ms ease,
-                box-shadow var(--duration) var(--ease-out);
-    text-decoration: none;
-  }
-  .btn-gold:hover {
-    background: var(--gold-hover);
-    box-shadow: var(--shadow-gold);
-    transform: translateY(-1px);
-  }
-  .btn-gold:active { transform: translateY(0); }
-  .btn-gold:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-
-  /* Botão outline ouro */
-  .btn-outline-gold {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--sp-2);
-    border: 1px solid var(--gold);
-    color: var(--gold);
-    font-family: var(--font-display);
-    font-weight: 600;
-    font-size: var(--text-sm);
-    padding: 10px 24px;
-    border-radius: var(--radius-md);
-    background: transparent;
-    cursor: pointer;
-    transition: background var(--duration) var(--ease-out),
-                box-shadow var(--duration) var(--ease-out),
-                transform 100ms ease;
-    text-decoration: none;
-  }
-  .btn-outline-gold:hover {
-    background: var(--gold-dim);
-    box-shadow: var(--shadow-gold);
-    transform: translateY(-1px);
-  }
-  .btn-outline-gold:active { transform: translateY(0); }
-
-  /* Input */
-  .input-lol {
-    @apply w-full rounded-lg px-3 py-2 text-white outline-none transition-colors;
+    @apply rounded-2xl;
     background: var(--surface);
     border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--sp-6);
+    transition: box-shadow var(--ease-ui), border-color var(--ease-ui), transform var(--ease-ui);
+  }
+  .card:hover {
+    box-shadow: var(--shadow-md);
+    border-color: var(--border-gold);
+  }
+  .card-sm {
+    background: var(--surface-2);
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius-md);
+    padding: var(--sp-4);
+    transition: box-shadow var(--ease-ui), border-color var(--ease-ui);
+  }
+  .card-sm:hover {
+    box-shadow: var(--shadow-sm);
+    border-color: var(--border-gold);
+  }
+  /* Alias legado */
+  .card-lol { @apply card; background: var(--surface-3); }
+
+  /* ── Botões — sistema unificado ── */
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 font-semibold;
+    font-family: var(--font-display);
+    border-radius: var(--radius-md);
+    padding: 10px 24px;
     font-size: var(--text-sm);
+    cursor: pointer;
+    border: none;
+    transition: background var(--ease-ui), box-shadow var(--ease-ui), transform var(--ease-bounce);
+    white-space: nowrap;
+    text-decoration: none;
+  }
+  .btn:active { transform: scale(0.97); }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
+
+  .btn-primary {
+    @apply btn;
+    background: var(--gold);
+    color: var(--text-inverse);
+  }
+  .btn-primary:hover {
+    background: var(--gold-hover);
+    box-shadow: var(--shadow-gold);
+  }
+
+  .btn-ghost {
+    @apply btn;
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+  }
+  .btn-ghost:hover {
+    border-color: var(--border-gold);
+    color: var(--gold);
+  }
+
+  .btn-sm { padding: 6px 14px; font-size: var(--text-xs); }
+
+  /* Aliases legado */
+  .btn-gold         { @apply btn-primary; }
+  .btn-outline-gold { @apply btn-ghost; }
+
+  /* ── Inputs ── */
+  .input-lol {
+    @apply w-full;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-2) var(--sp-3);
+    color: var(--text);
+    font-size: var(--text-sm);
+    transition: border-color var(--ease-ui), box-shadow var(--ease-ui);
+    outline: none;
   }
   .input-lol:focus {
     border-color: var(--gold);
-    box-shadow: 0 0 0 3px rgba(200,168,75,0.15);
+    box-shadow: 0 0 0 3px rgba(200, 168, 75, 0.15);
   }
+  .input-lol::placeholder { color: var(--text-faint); }
 
-  /* Badge de tier/rank */
-  .badge-tier {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--sp-1);
+  /* ── Badges ── */
+  .badge {
+    @apply inline-flex items-center gap-1;
     padding: 3px 10px;
     border-radius: var(--radius-full);
     font-size: var(--text-xs);
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    border: 1px solid transparent;
-  }
-
-  /* Pill de stat */
-  .stat-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    background: var(--gold-dim);
-    border: 1px solid var(--border-gold);
-    border-radius: var(--radius-full);
-    padding: 3px 10px;
-    font-size: var(--text-xs);
-    color: var(--gold);
     font-weight: 600;
+    font-family: var(--font-display);
+    letter-spacing: 0.03em;
   }
+  .badge-gold {
+    @apply badge;
+    background: var(--gold-dim);
+    color: var(--gold);
+    border: 1px solid rgba(200, 168, 75, 0.25);
+  }
+  .badge-win {
+    @apply badge;
+    background: var(--win-dim);
+    color: var(--win);
+  }
+  .badge-loss {
+    @apply badge;
+    background: var(--loss-dim);
+    color: var(--loss);
+  }
+  .badge-blue {
+    @apply badge;
+    background: var(--blue-dim);
+    color: var(--blue-accent);
+  }
+  .badge-tier { @apply badge; }
 
-  /* Tag win/loss */
-  .tag-win  { background: var(--win-dim);  color: var(--win);  border-radius: var(--radius-sm); padding: 2px 8px; font-size: var(--text-xs); font-weight: 700; }
-  .tag-loss { background: var(--loss-dim); color: var(--loss); border-radius: var(--radius-sm); padding: 2px 8px; font-size: var(--text-xs); font-weight: 700; }
+  /* Aliases legado */
+  .stat-pill  { @apply badge-gold; }
+  .tag-win    { @apply badge-win; }
+  .tag-loss   { @apply badge-loss; }
 
-  /* Divisor */
+  /* ── Skeleton ── */
+  .skeleton {
+    background: linear-gradient(
+      90deg,
+      var(--surface-2)      25%,
+      var(--surface-offset) 50%,
+      var(--surface-2)      75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+    border-radius: var(--radius-sm);
+  }
+  .skeleton-text    { @apply skeleton; height: 1em;   margin-bottom: var(--sp-2); }
+  .skeleton-heading { @apply skeleton; height: 1.5em; width: 40%; margin-bottom: var(--sp-4); }
+  .skeleton-avatar  { @apply skeleton; width: 40px; height: 40px; border-radius: var(--radius-full); }
+  .skeleton-image   { @apply skeleton; aspect-ratio: 16/9; width: 100%; }
+
+  /* ── Divisor ── */
   .divider {
     border: none;
     border-top: 1px solid var(--border-soft);
-    margin-block: var(--sp-4);
+    margin: var(--sp-6) 0;
   }
+
+  /* ── Section title ── */
+  .section-title {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.2;
+  }
+
+  /* ── Match row highlight ── */
+  .row-win  { background: linear-gradient(90deg, var(--win-dim) 0%, transparent 60%); }
+  .row-loss { background: linear-gradient(90deg, var(--loss-dim) 0%, transparent 60%); }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,9 @@
+/* ── Fontes — DEVE ser o primeiro statement antes dos @tailwind ─────── */
+@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@300;400;500;600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* ── Fontes ─────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@300;400;500;600&display=swap');
 
 /* ── Design Tokens — ArenaGG Dark Theme ─────────────────────────────── */
 :root {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,12 +2,130 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  background-color: #050D1A;
-  color: #C8A9A0;
+/* ── Fontes ─────────────────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@300;400;500;600&display=swap');
+
+/* ── Design Tokens — ArenaGG Dark Theme ─────────────────────────────── */
+:root {
+  /* Superfícies */
+  --bg:           #050D1A;
+  --surface:      #0A1428;
+  --surface-2:    #112240;
+  --surface-3:    #162b4d;
+
+  /* Bordas */
+  --border:       rgba(30,58,95,0.9);
+  --border-soft:  rgba(30,58,95,0.45);
+  --border-gold:  rgba(200,168,75,0.3);
+
+  /* Paleta de cor */
+  --gold:         #C8A84B;
+  --gold-hover:   #E8D48B;
+  --gold-dim:     rgba(200,168,75,0.15);
+  --blue-lol:     #0BC4E3;
+  --win:          #22C55E;
+  --win-dim:      rgba(34,197,94,0.12);
+  --loss:         #EF4444;
+  --loss-dim:     rgba(239,68,68,0.12);
+
+  /* Texto */
+  --text:         #F1F5F9;
+  --text-muted:   #94A3B8;
+  --text-faint:   #4B5563;
+  --text-inverse: #050D1A;
+
+  /* Tipografia */
+  --font-display: 'Sora', 'Inter', sans-serif;
+  --font-body:    'Inter', sans-serif;
+
+  /* Escala fluida */
+  --text-xs:   clamp(0.75rem,  0.7rem  + 0.25vw, 0.875rem);
+  --text-sm:   clamp(0.875rem, 0.8rem  + 0.35vw, 1rem);
+  --text-base: clamp(1rem,     0.95rem + 0.25vw, 1.125rem);
+  --text-lg:   clamp(1.125rem, 1rem    + 0.75vw, 1.5rem);
+  --text-xl:   clamp(1.5rem,   1.2rem  + 1.25vw, 2.25rem);
+  --text-2xl:  clamp(2rem,     1.2rem  + 2.5vw,  3.5rem);
+
+  /* Espaçamento 4px */
+  --sp-1:  0.25rem;
+  --sp-2:  0.5rem;
+  --sp-3:  0.75rem;
+  --sp-4:  1rem;
+  --sp-6:  1.5rem;
+  --sp-8:  2rem;
+  --sp-12: 3rem;
+  --sp-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+  --radius-full: 9999px;
+
+  /* Sombras */
+  --shadow-sm:   0 2px 8px rgba(0,0,0,0.35);
+  --shadow-card: 0 4px 20px rgba(0,0,0,0.45);
+  --shadow-hover:0 8px 32px rgba(0,0,0,0.65);
+  --shadow-gold: 0 0 20px rgba(200,168,75,0.2);
+
+  /* Transições */
+  --ease-out:  cubic-bezier(0.16, 1, 0.3, 1);
+  --duration:  180ms;
 }
 
-/* ── Animações globais ──────────────────────────────────────────────── */
+/* ── Base reset ──────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  scroll-padding-top: var(--sp-16);
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  min-height: 100dvh;
+}
+
+img, picture, video, canvas, svg { display: block; max-width: 100%; height: auto; }
+input, button, textarea, select { font: inherit; color: inherit; }
+h1,h2,h3,h4,h5,h6 { text-wrap: balance; line-height: 1.2; font-family: var(--font-display); }
+p, li { text-wrap: pretty; }
+
+::selection {
+  background: rgba(200,168,75,0.28);
+  color: var(--text);
+}
+
+:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ── Scrollbar ────────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: var(--surface); }
+::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: var(--radius-full); }
+::-webkit-scrollbar-thumb:hover { background: rgba(200,168,75,0.4); }
+
+/* ── Animações globais ────────────────────────────────────────────────── */
 @keyframes profile-frame-pulse {
   0%, 100% { opacity: 1; }
   50%       { opacity: 0.55; }
@@ -20,31 +138,156 @@ body {
   0%   { stroke-dashoffset: 0; }
   100% { stroke-dashoffset: -565; }
 }
-
-.profile-frame-ring {
-  animation: profile-frame-pulse 2.4s ease-in-out infinite;
+@keyframes shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position:  200% 0; }
 }
-.profile-frame-dash {
-  animation: profile-frame-dash 8s linear infinite;
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50%       { transform: translateY(-6px); }
 }
 
+.profile-frame-ring  { animation: profile-frame-pulse 2.4s ease-in-out infinite; }
+.profile-frame-dash  { animation: profile-frame-dash  8s   linear     infinite; }
+.animate-float       { animation: float 3s ease-in-out infinite; }
+
+/* ── Skeleton loader ─────────────────────────────────────────────────── */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--surface) 25%,
+    var(--surface-2) 50%,
+    var(--surface) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+/* ── Componentes ─────────────────────────────────────────────────────── */
 @layer components {
+  /* Card base */
+  .card {
+    @apply rounded-2xl border p-6;
+    background: var(--surface);
+    border-color: var(--border);
+    box-shadow: var(--shadow-card);
+    transition: box-shadow var(--duration) var(--ease-out),
+                border-color var(--duration) var(--ease-out),
+                transform var(--duration) var(--ease-out);
+  }
+  .card:hover {
+    box-shadow: var(--shadow-hover);
+    border-color: var(--border-gold);
+  }
+
+  /* Card legado — mantido para compatibilidade */
   .card-lol {
-    @apply bg-[#112240] border border-[#1E3A5F] rounded-lg p-4;
+    @apply card;
   }
+
+  /* Botão primário (ouro) */
   .btn-gold {
-    @apply bg-[#C8A84B] text-[#0A1428] font-bold px-4 py-2 rounded hover:bg-[#E8D48B] transition-colors disabled:opacity-50;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--sp-2);
+    background: var(--gold);
+    color: var(--text-inverse);
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: var(--text-sm);
+    padding: 10px 24px;
+    border-radius: var(--radius-md);
+    border: none;
+    cursor: pointer;
+    transition: background var(--duration) var(--ease-out),
+                transform 100ms ease,
+                box-shadow var(--duration) var(--ease-out);
+    text-decoration: none;
   }
+  .btn-gold:hover {
+    background: var(--gold-hover);
+    box-shadow: var(--shadow-gold);
+    transform: translateY(-1px);
+  }
+  .btn-gold:active { transform: translateY(0); }
+  .btn-gold:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
+
+  /* Botão outline ouro */
   .btn-outline-gold {
-    @apply border border-[#C8A84B] text-[#C8A84B] px-4 py-2 rounded hover:bg-[#C8A84B]/10 transition-colors;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--sp-2);
+    border: 1px solid var(--gold);
+    color: var(--gold);
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: var(--text-sm);
+    padding: 10px 24px;
+    border-radius: var(--radius-md);
+    background: transparent;
+    cursor: pointer;
+    transition: background var(--duration) var(--ease-out),
+                box-shadow var(--duration) var(--ease-out),
+                transform 100ms ease;
+    text-decoration: none;
   }
+  .btn-outline-gold:hover {
+    background: var(--gold-dim);
+    box-shadow: var(--shadow-gold);
+    transform: translateY(-1px);
+  }
+  .btn-outline-gold:active { transform: translateY(0); }
+
+  /* Input */
   .input-lol {
-    @apply w-full bg-[#0A1428] border border-[#1E3A5F] rounded px-3 py-2 text-white focus:border-[#C8A84B] outline-none transition-colors;
+    @apply w-full rounded-lg px-3 py-2 text-white outline-none transition-colors;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    font-size: var(--text-sm);
   }
+  .input-lol:focus {
+    border-color: var(--gold);
+    box-shadow: 0 0 0 3px rgba(200,168,75,0.15);
+  }
+
+  /* Badge de tier/rank */
   .badge-tier {
-    @apply inline-flex items-center px-2 py-0.5 rounded text-xs font-bold;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-1);
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    border: 1px solid transparent;
+  }
+
+  /* Pill de stat */
+  .stat-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: var(--gold-dim);
+    border: 1px solid var(--border-gold);
+    border-radius: var(--radius-full);
+    padding: 3px 10px;
+    font-size: var(--text-xs);
+    color: var(--gold);
+    font-weight: 600;
+  }
+
+  /* Tag win/loss */
+  .tag-win  { background: var(--win-dim);  color: var(--win);  border-radius: var(--radius-sm); padding: 2px 8px; font-size: var(--text-xs); font-weight: 700; }
+  .tag-loss { background: var(--loss-dim); color: var(--loss); border-radius: var(--radius-sm); padding: 2px 8px; font-size: var(--text-xs); font-weight: 700; }
+
+  /* Divisor */
+  .divider {
+    border: none;
+    border-top: 1px solid var(--border-soft);
+    margin-block: var(--sp-4);
   }
 }
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: #0A1428; }
-::-webkit-scrollbar-thumb { background: #1E3A5F; border-radius: 3px; }

--- a/app/jogadores/[gameName]/[tagLine]/loading.tsx
+++ b/app/jogadores/[gameName]/[tagLine]/loading.tsx
@@ -1,0 +1,140 @@
+export default function PlayerProfileLoading() {
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--bg)' }}>
+
+      {/* ── Hero Banner skeleton ── */}
+      <div
+        style={{
+          background: 'var(--surface)',
+          borderBottom: '1px solid var(--border)',
+          minHeight: 260,
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        {/* splash fundo */}
+        <div
+          className="skeleton"
+          style={{
+            position: 'absolute', inset: 0,
+            borderRadius: 0,
+            opacity: 0.4,
+          }}
+        />
+        {/* conteúdo hero */}
+        <div
+          style={{
+            position: 'relative',
+            maxWidth: 'var(--content-wide)',
+            margin: '0 auto',
+            padding: 'var(--sp-8) var(--sp-4)',
+            display: 'flex',
+            alignItems: 'flex-end',
+            gap: 'var(--sp-6)',
+            minHeight: 260,
+          }}
+        >
+          {/* Avatar */}
+          <div
+            className="skeleton"
+            style={{
+              width: 100, height: 100,
+              borderRadius: 'var(--radius-xl)',
+              flexShrink: 0,
+              border: '3px solid var(--border)',
+            }}
+          />
+          {/* Nome + stats */}
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--sp-3)', paddingBottom: 'var(--sp-2)' }}>
+            <div className="skeleton" style={{ height: 32, width: 220, borderRadius: 'var(--radius-sm)' }} />
+            <div className="skeleton" style={{ height: 16, width: 140, borderRadius: 'var(--radius-sm)' }} />
+            <div style={{ display: 'flex', gap: 'var(--sp-2)', marginTop: 'var(--sp-1)' }}>
+              {[80, 96, 72, 88].map((w, i) => (
+                <div key={i} className="skeleton" style={{ height: 26, width: w, borderRadius: 'var(--radius-full)' }} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Corpo skeleton ── */}
+      <div
+        style={{
+          maxWidth: 'var(--content-wide)',
+          margin: '0 auto',
+          padding: 'var(--sp-6) var(--sp-4)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--sp-6)',
+        }}
+      >
+        {/* Rank Cards */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 'var(--sp-4)' }}>
+          {[0, 1].map((i) => (
+            <div key={i} className="card" style={{ display: 'flex', gap: 'var(--sp-4)', alignItems: 'center', minHeight: 120 }}>
+              <div className="skeleton" style={{ width: 72, height: 72, borderRadius: 'var(--radius-lg)', flexShrink: 0 }} />
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
+                <div className="skeleton" style={{ height: 12, width: 80, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 20, width: 120, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 12, width: 60, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 6, borderRadius: 'var(--radius-full)' }} />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Maestria */}
+        <div className="card" style={{ padding: 'var(--sp-6)' }}>
+          <div className="skeleton" style={{ height: 16, width: 140, borderRadius: 'var(--radius-sm)', marginBottom: 'var(--sp-4)' }} />
+          <div style={{ display: 'flex', gap: 'var(--sp-3)', flexWrap: 'wrap' }}>
+            {Array.from({ length: 7 }).map((_, i) => (
+              <div key={i} className="skeleton" style={{ width: 72, height: 88, borderRadius: 'var(--radius-md)' }} />
+            ))}
+          </div>
+        </div>
+
+        {/* Histórico */}
+        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          {/* Header */}
+          <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border-soft)' }}>
+            <div className="skeleton" style={{ height: 14, width: 180, borderRadius: 'var(--radius-sm)' }} />
+          </div>
+          {/* Linhas */}
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--sp-3)',
+                padding: 'var(--sp-3) var(--sp-4)',
+                borderBottom: i < 4 ? '1px solid var(--border-soft)' : 'none',
+              }}
+            >
+              {/* win/loss bar */}
+              <div className="skeleton" style={{ width: 4, height: 52, borderRadius: 'var(--radius-full)', flexShrink: 0 }} />
+              {/* champion */}
+              <div className="skeleton" style={{ width: 44, height: 44, borderRadius: 'var(--radius-md)', flexShrink: 0 }} />
+              {/* info */}
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
+                <div className="skeleton" style={{ height: 14, width: 80, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 12, width: 110, borderRadius: 'var(--radius-sm)' }} />
+              </div>
+              {/* KDA */}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-1)', alignItems: 'flex-end' }}>
+                <div className="skeleton" style={{ height: 14, width: 64, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 12, width: 48, borderRadius: 'var(--radius-sm)' }} />
+              </div>
+              {/* itens */}
+              <div style={{ display: 'flex', gap: 4 }} className="hidden sm:flex">
+                {Array.from({ length: 6 }).map((_, j) => (
+                  <div key={j} className="skeleton" style={{ width: 28, height: 28, borderRadius: 'var(--radius-sm)' }} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/jogadores/[gameName]/[tagLine]/not-found.tsx
+++ b/app/jogadores/[gameName]/[tagLine]/not-found.tsx
@@ -1,24 +1,48 @@
 import Link from "next/link";
+import { SearchX } from "lucide-react";
 
 export default function NotFoundJogador() {
   return (
-    <div className="min-h-screen bg-[#050E1A] flex items-center justify-center px-4">
+    <div
+      className="min-h-screen flex items-center justify-center px-4"
+      style={{ background: "var(--bg)" }}
+    >
       <div style={{ textAlign: "center", maxWidth: 400 }}>
-        <p style={{ fontSize: 56, marginBottom: 16 }}>🔍</p>
-        <h1 style={{ fontSize: 22, fontWeight: 800, color: "#fff", marginBottom: 8 }}>
-          Jogador não encontrado
-        </h1>
-        <p style={{ fontSize: 14, color: "#6B7280", marginBottom: 24 }}>
-          Verifique o nick e a tag e tente novamente.
-        </p>
-        <Link
-          href="/jogadores"
+        <div
+          className="mx-auto mb-6 flex items-center justify-center"
           style={{
-            background: "#C8A84B", color: "#050E1A",
-            fontWeight: 700, borderRadius: 8, padding: "10px 24px",
-            textDecoration: "none", fontSize: 14,
+            width: 72,
+            height: 72,
+            borderRadius: "var(--radius-xl)",
+            background: "var(--surface-2)",
+            border: "1px solid var(--border)",
+            color: "var(--text-muted)",
+            margin: "0 auto var(--sp-6)",
           }}
         >
+          <SearchX size={32} />
+        </div>
+        <h1
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "var(--text-lg)",
+            fontWeight: 800,
+            color: "var(--text)",
+            marginBottom: "var(--sp-2)",
+          }}
+        >
+          Jogador não encontrado
+        </h1>
+        <p
+          style={{
+            fontSize: "var(--text-sm)",
+            color: "var(--text-muted)",
+            marginBottom: "var(--sp-6)",
+          }}
+        >
+          Verifique o nick e a tag e tente novamente.
+        </p>
+        <Link href="/jogadores" className="btn-primary">
           ← Voltar para Jogadores
         </Link>
       </div>

--- a/app/jogadores/[gameName]/[tagLine]/page.tsx
+++ b/app/jogadores/[gameName]/[tagLine]/page.tsx
@@ -1,61 +1,18 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import {
-  getAccountByRiotId,
-  getSummonerByPuuid,
-  getLeagueEntriesByPuuid,
-  getTopMasteriesByPuuid,
-  getMatchIdsByPuuid,
-  getMatchById,
-  getAllChampions,
-  profileIconUrl,
-  profileIconBorderStyle,
-  profileBorderUrl,
-  championIconByCDragon,
-  championSplashUrl,
-  rankEmblemUrl,
-  masteryLevelColor,
-  getDDVersion,
+  getAccountByRiotId, getSummonerByPuuid, getLeagueEntriesByPuuid,
+  getTopMasteriesByPuuid, getMatchIdsByPuuid, getMatchById,
+  getAllChampions, profileIconUrl, profileIconBorderStyle,
+  profileBorderUrl, championSplashUrl, getDDVersion,
 } from "@/lib/riot";
 import { createClient } from "@/lib/supabase/server";
 import type { MatchParticipant } from "@/lib/riot";
+import { HeroBanner }   from "@/components/profile/HeroBanner";
+import { RankCard }     from "@/components/profile/RankCard";
+import { MasteryGrid }  from "@/components/profile/MasteryGrid";
+import { MatchRow }     from "@/components/profile/MatchRow";
 
 export const maxDuration = 60;
-
-const TIER_COLORS: Record<string, string> = {
-  IRON: "#8B7A6B", BRONZE: "#CD7F32", SILVER: "#A8A9AD", GOLD: "#FFD700",
-  PLATINUM: "#00E5CC", EMERALD: "#50C878", DIAMOND: "#99CCFF",
-  MASTER: "#9B59B6", GRANDMASTER: "#E74C3C", CHALLENGER: "#00D4FF",
-};
-
-const QUEUE_NAMES: Record<number, string> = {
-  420: "Solo/Duo Ranqueada", 440: "Flex 5v5 Ranqueada", 450: "ARAM",
-  400: "Normal Draft", 430: "Normal Cega", 0: "Personalizada",
-};
-
-const POSITION_PT: Record<string, string> = {
-  TOP: "Top", JUNGLE: "Jungle", MIDDLE: "Mid",
-  BOTTOM: "ADC", UTILITY: "Suporte", NONE: "—",
-};
-
-function itemIconUrl(ddVersion: string, itemId: number): string {
-  if (!itemId || itemId === 0) return "";
-  return `https://ddragon.leagueoflegends.com/cdn/${ddVersion}/img/item/${itemId}.png`;
-}
-
-function fmtDuration(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}m ${s.toString().padStart(2, "0")}s`;
-}
-
-function timeAgo(ts: number): string {
-  const diff = Math.floor((Date.now() - ts) / 1000);
-  if (diff < 60)    return `${diff}s atrás`;
-  if (diff < 3600)  return `${Math.floor(diff / 60)}min atrás`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h atrás`;
-  return `${Math.floor(diff / 86400)}d atrás`;
-}
 
 function cleanGameName(raw: string): string {
   const idx = raw.indexOf('#');
@@ -64,33 +21,26 @@ function cleanGameName(raw: string): string {
 
 export async function generateMetadata({
   params,
-}: {
-  params: Promise<{ gameName: string; tagLine: string }>;
-}) {
+}: { params: Promise<{ gameName: string; tagLine: string }> }) {
   const { gameName, tagLine } = await params;
   const name = cleanGameName(decodeURIComponent(gameName));
   const tag  = decodeURIComponent(tagLine);
   return {
-    title: `${name}#${tag} — LoL Tournament BR`,
-    description: `Perfil competitivo de ${name} no LoL Tournament BR`,
+    title: `${name}#${tag} — ArenaGG`,
+    description: `Perfil competitivo de ${name} no ArenaGG`,
   };
 }
 
 export default async function PlayerProfilePage({
   params,
-}: {
-  params: Promise<{ gameName: string; tagLine: string }>;
-}) {
+}: { params: Promise<{ gameName: string; tagLine: string }> }) {
   const { gameName: rawName, tagLine: rawTag } = await params;
   const gameName = cleanGameName(decodeURIComponent(rawName));
   const tagLine  = decodeURIComponent(rawTag);
 
   let account;
-  try {
-    account = await getAccountByRiotId(gameName, tagLine);
-  } catch {
-    return notFound();
-  }
+  try { account = await getAccountByRiotId(gameName, tagLine); }
+  catch { return notFound(); }
   const { puuid } = account;
 
   const [summoner, leagueEntries, masteries, matchIds, champMap] = await Promise.allSettled([
@@ -110,9 +60,7 @@ export default async function PlayerProfilePage({
   const champById: Record<number, string> = {};
   for (const c of Object.values(champs)) champById[Number(c.key)] = c.name;
 
-  const matchResults = await Promise.allSettled(
-    mIds.slice(0, 5).map((id) => getMatchById(id))
-  );
+  const matchResults = await Promise.allSettled(mIds.slice(0, 5).map((id) => getMatchById(id)));
   const matches = matchResults
     .filter((r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof getMatchById>>> => r.status === "fulfilled")
     .map((r) => r.value);
@@ -132,11 +80,10 @@ export default async function PlayerProfilePage({
   const supabase = await createClient();
   const { data: riotRows } = await supabase
     .from("riot_accounts")
-    .select(`id, profile_id, profiles ( full_name ), champion_masteries ( champion_id, champion_name, mastery_level, mastery_points )`)
+    .select(`id, profile_id, profiles ( full_name )`)
     .ilike("game_name", gameName)
     .ilike("tag_line",  tagLine)
     .limit(1);
-
   const riotRow = riotRows?.[0] ?? null;
 
   const myMatches = matches
@@ -154,7 +101,7 @@ export default async function PlayerProfilePage({
   return (
     <div className="min-h-screen bg-[#050E1A]">
       <style>{`
-        .match-row:hover { background: rgba(30,58,95,0.5); }
+        .match-row:hover { background: rgba(30,58,95,0.4) !important; }
         .stat-pill {
           display:inline-flex; align-items:center; gap:4px;
           background:rgba(200,168,75,0.1); border:1px solid rgba(200,168,75,0.25);
@@ -163,236 +110,89 @@ export default async function PlayerProfilePage({
         }
       `}</style>
 
-      {/* HERO BANNER */}
-      <div className="relative w-full overflow-hidden" style={{ minHeight: 260 }}>
-        {mainSplash ? (
-          <div style={{ position:"absolute", inset:0, backgroundImage:`url(${mainSplash})`, backgroundSize:"cover", backgroundPosition:"center 15%", filter:"brightness(0.35) saturate(1.2)" }} />
-        ) : (
-          <div style={{ position:"absolute", inset:0, background:"#050E1A" }} />
-        )}
-        <div style={{ position:"absolute", inset:0, background:"linear-gradient(to bottom, transparent 40%, #050E1A 100%)" }} />
-
-        <div className="relative max-w-6xl mx-auto px-4 pt-10 pb-8" style={{ display:"flex", alignItems:"flex-end", gap:24, flexWrap:"wrap" }}>
-
-          {/* ── Ícone + Moldura por nível ── */}
-          <div style={{ position:"relative", width:110, height:126, flexShrink:0 }}>
-            {iconUrl && (
-              <>
-                {/* Ícone de perfil — fica embaixo da moldura */}
-                <img
-                  src={iconUrl}
-                  width={86}
-                  height={86}
-                  alt="Ícone de perfil"
-                  style={{
-                    position:"absolute",
-                    top:12, left:12,
-                    width:86, height:86,
-                    borderRadius:"50%",
-                    display:"block",
-                    zIndex:1,
-                  }}
-                />
-                {/* Moldura real do CDragon — cobre o ícone (PNG transparente) */}
-                {borderImg && (
-                  <img
-                    src={borderImg}
-                    width={110}
-                    height={110}
-                    alt=""
-                    aria-hidden="true"
-                    style={{
-                      position:"absolute",
-                      top:0, left:0,
-                      width:110, height:110,
-                      display:"block",
-                      zIndex:2,
-                      pointerEvents:"none",
-                    }}
-                  />
-                )}
-                {/* Badge de nível */}
-                <span style={{
-                  position:"absolute",
-                  bottom:0, left:"50%",
-                  transform:"translateX(-50%)",
-                  zIndex:3,
-                  background:"#050E1A",
-                  border:`1.5px solid ${borderStyle.color}`,
-                  color:borderStyle.color,
-                  fontSize:11, fontWeight:700,
-                  padding:"2px 10px",
-                  borderRadius:9999, lineHeight:"16px",
-                  whiteSpace:"nowrap",
-                  boxShadow:`0 0 8px ${borderStyle.glow}`,
-                }}>
-                  Nv. {level}
-                </span>
-              </>
-            )}
-          </div>
-
-          {/* Nome + stats */}
-          <div style={{ flex:1, minWidth:0 }}>
-            <div style={{ display:"flex", alignItems:"center", gap:10, flexWrap:"wrap", marginBottom:6 }}>
-              <h1 style={{ fontSize:28, fontWeight:800, color:"#fff", lineHeight:1.1, letterSpacing:"-0.5px" }}>
-                {account.gameName}
-              </h1>
-              <span style={{ color:"#6B7280", fontSize:22, fontWeight:700 }}>#{account.tagLine}</span>
-              {mainChampName && <span className="stat-pill">⚔️ {mainChampName}</span>}
-            </div>
-            <div style={{ display:"flex", gap:8, flexWrap:"wrap", alignItems:"center" }}>
-              {totalGames > 0 && (
-                <>
-                  <span className="stat-pill">{totalGames} jogos recentes</span>
-                  <span className="stat-pill" style={{
-                    background: recentWR >= 50 ? "rgba(74,222,128,0.1)" : "rgba(248,113,113,0.1)",
-                    borderColor: recentWR >= 50 ? "rgba(74,222,128,0.3)" : "rgba(248,113,113,0.3)",
-                    color: recentWR >= 50 ? "#4ADE80" : "#F87171",
-                  }}>
-                    {totalWins}V {totalLosses}D · {recentWR}% WR
-                  </span>
-                  <span className="stat-pill">KDA médio {avgKDA}</span>
-                </>
-              )}
-              {riotRow?.profiles && (
-                <span className="stat-pill" style={{ color:"#60A5FA", borderColor:"rgba(96,165,250,0.3)", background:"rgba(96,165,250,0.1)" }}>
-                  👤 {(riotRow.profiles as any).full_name}
-                </span>
-              )}
-            </div>
-          </div>
-
-          <Link href="/jogadores" style={{ fontSize:13, color:"#9CA3AF", border:"1px solid #1E3A5F", borderRadius:8, padding:"6px 14px", background:"rgba(10,20,40,0.7)", textDecoration:"none", flexShrink:0, alignSelf:"flex-start", marginTop:4 }}>
-            ← Jogadores
-          </Link>
-        </div>
-      </div>
+      {/* HERO BANNER — componente isolado */}
+      <HeroBanner
+        gameName={account.gameName}
+        tagLine={account.tagLine}
+        level={level}
+        iconUrl={iconUrl}
+        borderImg={borderImg}
+        borderStyle={borderStyle}
+        mainSplash={mainSplash}
+        mainChampName={mainChampName ?? null}
+        totalGames={totalGames}
+        totalWins={totalWins}
+        totalLosses={totalLosses}
+        recentWR={recentWR}
+        avgKDA={avgKDA}
+        profileName={(riotRow?.profiles as any)?.full_name ?? null}
+      />
 
       {/* CORPO */}
       <div className="max-w-6xl mx-auto px-4 py-6 space-y-6">
 
-        {/* RANK CARDS */}
+        {/* RANK CARDS — componente isolado, sem border-left colorido */}
         {(rankSolo || rankFlex) && (
-          <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fill, minmax(280px, 1fr))", gap:16 }}>
-            {[rankSolo, rankFlex].filter(Boolean).map((r) => {
-              const tier  = r!.tier;
-              const color = TIER_COLORS[tier] ?? "#fff";
-              const total = r!.wins + r!.losses;
-              const wr    = total > 0 ? Math.round((r!.wins / total) * 100) : 0;
-              return (
-                <div key={r!.queueType} style={{ background:"#0A1428", border:"1px solid rgba(30,58,95,0.8)", borderRadius:16, padding:"20px 20px 20px 16px", display:"flex", alignItems:"center", gap:16, position:"relative", overflow:"hidden" }}>
-                  <div style={{ position:"absolute", left:0, top:16, bottom:16, width:3, borderRadius:9999, background:color, boxShadow:`0 0 10px ${color}88` }} />
-                  <img
-                    src={rankEmblemUrl(tier)}
-                    width={80} height={80}
-                    alt={tier}
-                    style={{ width:80, height:80, objectFit:"contain", flexShrink:0 }}
-                  />
-                  <div style={{ flex:1, minWidth:0 }}>
-                    <p style={{ color:"#9CA3AF", fontSize:11, fontWeight:700, textTransform:"uppercase", letterSpacing:"0.08em", marginBottom:4 }}>
-                      {r!.queueType === "RANKED_SOLO_5x5" ? "Solo / Duo" : "Flex 5v5"}
-                    </p>
-                    <p style={{ fontSize:22, fontWeight:800, color, lineHeight:1.1, marginBottom:2 }}>
-                      {tier} <span style={{ fontSize:18 }}>{r!.rank}</span>
-                    </p>
-                    <p style={{ fontSize:14, color:"#fff", fontWeight:600, marginBottom:6 }}>{r!.leaguePoints} LP</p>
-                    <div style={{ display:"flex", alignItems:"center", gap:8 }}>
-                      <div style={{ flex:1, height:5, borderRadius:9999, background:"#1E3A5F", overflow:"hidden" }}>
-                        <div style={{ width:`${wr}%`, height:"100%", borderRadius:9999, background: wr >= 50 ? "#4ADE80" : "#F87171" }} />
-                      </div>
-                      <span style={{ fontSize:12, color: wr >= 50 ? "#4ADE80" : "#F87171", fontWeight:700, minWidth:38 }}>{wr}%</span>
-                    </div>
-                    <p style={{ fontSize:11, color:"#6B7280", marginTop:4 }}>{r!.wins}V · {r!.losses}D · {total} jogos</p>
-                    <div style={{ display:"flex", gap:4, flexWrap:"wrap", marginTop:8 }}>
-                      {r!.hotStreak && <span style={{ fontSize:10, background:"rgba(249,115,22,0.15)", color:"#FB923C", border:"1px solid rgba(249,115,22,0.3)", borderRadius:9999, padding:"2px 7px", fontWeight:700 }}>🔥 Hot Streak</span>}
-                      {r!.veteran   && <span style={{ fontSize:10, background:"rgba(200,168,75,0.12)", color:"#C8A84B", border:"1px solid rgba(200,168,75,0.3)", borderRadius:9999, padding:"2px 7px", fontWeight:700 }}>⚔️ Veterano</span>}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 16 }}>
+            {[rankSolo, rankFlex].filter(Boolean).map((r) => (
+              <RankCard key={r!.queueType} r={r!} />
+            ))}
           </div>
         )}
 
-        {/* TOP CAMPEÕES */}
-        {tops.length > 0 && (
-          <div style={{ background:"#0A1428", border:"1px solid rgba(30,58,95,0.8)", borderRadius:16, padding:"20px" }}>
-            <p style={{ color:"#9CA3AF", fontSize:11, fontWeight:700, textTransform:"uppercase", letterSpacing:"0.1em", marginBottom:14 }}>🏆 Top Campeões — Maestria</p>
-            <div style={{ display:"flex", gap:12, flexWrap:"wrap" }}>
-              {tops.map((m) => {
-                const name  = champById[m.championId] ?? m.championName;
-                const color = masteryLevelColor(m.championLevel);
-                const pts   = m.championPoints >= 1_000_000 ? `${(m.championPoints/1_000_000).toFixed(1)}M`
-                            : m.championPoints >= 1000      ? `${(m.championPoints/1000).toFixed(0)}k`
-                            : String(m.championPoints);
-                return (
-                  <div key={m.championId} style={{ display:"flex", flexDirection:"column", alignItems:"center", gap:4, background:"rgba(10,20,40,0.7)", border:`1.5px solid ${color}44`, borderRadius:12, padding:"10px 10px 8px", minWidth:76 }} title={`${name} — M${m.championLevel} — ${pts}`}>
-                    <div style={{ position:"relative", width:52, height:52 }}>
-                      <img src={championIconByCDragon(m.championId)} width={52} height={52} alt={name} style={{ width:52, height:52, borderRadius:8, objectFit:"cover", display:"block", border:`2px solid ${color}` }} />
-                      <span style={{ position:"absolute", bottom:-6, right:-6, background:"#050E1A", border:`1px solid ${color}`, color, fontSize:9, fontWeight:800, borderRadius:9999, padding:"1px 5px", lineHeight:"14px", whiteSpace:"nowrap", zIndex:2 }}>M{m.championLevel}</span>
-                    </div>
-                    <p style={{ fontSize:11, color:"#D1D5DB", maxWidth:72, overflow:"hidden", textOverflow:"ellipsis", whiteSpace:"nowrap", textAlign:"center", marginTop:8 }}>{name}</p>
-                    <p style={{ fontSize:11, color, fontWeight:700, textAlign:"center" }}>{pts}</p>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
+        {/* MAESTRIA — componente isolado */}
+        <MasteryGrid masteries={tops} champById={champById} />
 
-        {/* HISTÓRICO */}
+        {/* HISTÓRICO — componente MatchRow isolado por partida */}
         {myMatches.length > 0 && (
-          <div style={{ background:"#0A1428", border:"1px solid rgba(30,58,95,0.8)", borderRadius:16, overflow:"hidden" }}>
-            <div style={{ padding:"16px 20px 12px", borderBottom:"1px solid rgba(30,58,95,0.6)" }}>
-              <p style={{ color:"#9CA3AF", fontSize:11, fontWeight:700, textTransform:"uppercase", letterSpacing:"0.1em" }}>📋 Histórico Recente ({myMatches.length} partidas)</p>
+          <div style={{ background: "#0A1428", border: "1px solid rgba(30,58,95,0.8)", borderRadius: 16, overflow: "hidden" }}>
+            <div style={{ padding: "16px 20px 12px", borderBottom: "1px solid rgba(30,58,95,0.6)" }}>
+              <p style={{ color: "#9CA3AF", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em" }}>
+                📋 Histórico Recente ({myMatches.length} partidas)
+              </p>
             </div>
             <div>
-              {myMatches.map(({ match, me }) => {
-                const p         = me!;
-                const win       = p.win;
-                const kda       = ((p.kills + p.assists) / Math.max(1, p.deaths)).toFixed(2);
-                const champName = champById[p.championId] ?? p.championName;
-                const queueName = QUEUE_NAMES[match.info.queueId] ?? `Fila ${match.info.queueId}`;
-                const duration  = fmtDuration(match.info.gameDuration);
-                const ago       = timeAgo(match.info.gameStartTimestamp);
-                const items     = [p.item0, p.item1, p.item2, p.item3, p.item4, p.item5];
-                const pos       = POSITION_PT[p.teamPosition] ?? POSITION_PT[p.individualPosition] ?? "—";
-                return (
-                  <div key={match.metadata.matchId} className="match-row" style={{ display:"flex", alignItems:"center", gap:12, padding:"12px 16px", borderBottom:"1px solid rgba(30,58,95,0.4)", transition:"background 0.15s", borderLeft:`3px solid ${win ? "#22C55E" : "#EF4444"}` }}>
-                    <div style={{ width:36, flexShrink:0, textAlign:"center", fontSize:12, fontWeight:800, color: win ? "#4ADE80" : "#F87171" }}>{win ? "V" : "D"}</div>
-                    <div style={{ position:"relative", flexShrink:0 }}>
-                      <img src={championIconByCDragon(p.championId)} width={44} height={44} alt={champName} style={{ width:44, height:44, borderRadius:8, objectFit:"cover", display:"block", border:`2px solid ${win ? "#22C55E44" : "#EF444444"}` }} />
-                      {pos !== "—" && <span style={{ position:"absolute", bottom:-4, right:-4, background:"#050E1A", fontSize:8, fontWeight:700, color:"#C8A84B", border:"1px solid #1E3A5F", borderRadius:4, padding:"1px 3px", lineHeight:1.2 }}>{pos}</span>}
-                    </div>
-                    <div style={{ minWidth:90, flexShrink:0 }}>
-                      <p style={{ fontSize:14, fontWeight:700, color:"#fff", lineHeight:1 }}>{p.kills} / <span style={{ color:"#F87171" }}>{p.deaths}</span> / {p.assists}</p>
-                      <p style={{ fontSize:11, color:"#9CA3AF", marginTop:2 }}>KDA <span style={{ color: Number(kda) >= 3 ? "#4ADE80" : "#9CA3AF", fontWeight:700 }}>{kda}</span></p>
-                    </div>
-                    <div style={{ display:"flex", gap:3, flexShrink:0, flexWrap:"wrap", maxWidth:180 }}>
-                      {items.map((itemId, idx) => (
-                        <div key={idx} style={{ width:24, height:24, background: itemId ? "#0A1E38" : "rgba(30,58,95,0.3)", borderRadius:4, overflow:"hidden", border:"1px solid rgba(30,58,95,0.6)", flexShrink:0 }}>
-                          {itemId > 0 && <img src={itemIconUrl(ddVersion, itemId)} width={24} height={24} alt="" style={{ width:24, height:24, display:"block" }} />}
-                        </div>
-                      ))}
-                    </div>
-                    <div style={{ marginLeft:"auto", textAlign:"right", flexShrink:0 }}>
-                      <p style={{ fontSize:11, color:"#9CA3AF", lineHeight:1 }}>{queueName}</p>
-                      <p style={{ fontSize:11, color:"#6B7280", marginTop:2 }}>{duration} · {ago}</p>
-                      {p.pentaKills > 0 && <p style={{ fontSize:11, color:"#FFD700", fontWeight:700, marginTop:2 }}>PENTA KILL 🎉</p>}
-                    </div>
-                  </div>
-                );
-              })}
+              {myMatches.map(({ match, me }) => (
+                <MatchRow
+                  key={match.metadata.matchId}
+                  matchId={match.metadata.matchId}
+                  win={me!.win}
+                  championId={me!.championId}
+                  championName={me!.championName}
+                  kills={me!.kills}
+                  deaths={me!.deaths}
+                  assists={me!.assists}
+                  teamPosition={me!.teamPosition}
+                  individualPosition={me!.individualPosition}
+                  items={[me!.item0, me!.item1, me!.item2, me!.item3, me!.item4, me!.item5]}
+                  queueId={match.info.queueId}
+                  gameDuration={match.info.gameDuration}
+                  gameStartTimestamp={match.info.gameStartTimestamp}
+                  pentaKills={me!.pentaKills}
+                  ddVersion={ddVersion}
+                  champById={champById}
+                />
+              ))}
             </div>
           </div>
         )}
 
+        {/* EMPTY STATE */}
         {totalGames === 0 && (
-          <div style={{ textAlign:"center", padding:"60px 20px", color:"#4B5563" }}>
-            <p style={{ fontSize:40, marginBottom:12 }}>🎮</p>
-            <p style={{ fontSize:16, fontWeight:600 }}>Nenhuma partida recente encontrada</p>
-            <p style={{ fontSize:13, marginTop:6 }}>Os dados são atualizados automaticamente.</p>
+          <div style={{ textAlign: "center", padding: "60px 20px" }}>
+            <div
+              style={{
+                width: 64, height: 64, borderRadius: 16,
+                background: "rgba(200,168,75,0.08)",
+                border: "1px solid rgba(200,168,75,0.2)",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                margin: "0 auto 16px", fontSize: 28,
+              }}
+            >
+              🎮
+            </div>
+            <p style={{ fontSize: 16, fontWeight: 600, color: "#D1D5DB" }}>Nenhuma partida recente encontrada</p>
+            <p style={{ fontSize: 13, color: "#4B5563", marginTop: 6 }}>Os dados são atualizados automaticamente.</p>
           </div>
         )}
       </div>

--- a/app/jogadores/[gameName]/[tagLine]/page.tsx
+++ b/app/jogadores/[gameName]/[tagLine]/page.tsx
@@ -4,7 +4,6 @@ import {
   getTopMasteriesByPuuid, getMatchIdsByPuuid, getMatchById,
   getAllChampions, profileIconUrl, profileIconBorderStyle,
   profileBorderUrl, championSplashUrl,
-  // getDDVersion removido — PR14: MatchRow usa versão pinada internamente
 } from "@/lib/riot";
 import { createClient } from "@/lib/supabase/server";
 import type { MatchParticipant } from "@/lib/riot";
@@ -67,7 +66,6 @@ export default async function PlayerProfilePage({
     .filter((r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof getMatchById>>> => r.status === "fulfilled")
     .map((r) => r.value);
 
-  // getDDVersion removido — PR14: MatchRow encapsula versão de CDN internamente
   const iconUrl     = sum ? await profileIconUrl(sum.profileIconId) : null;
   const level       = sum?.summonerLevel ?? 0;
   const borderStyle = profileIconBorderStyle(level);
@@ -79,15 +77,16 @@ export default async function PlayerProfilePage({
   const mainChampName = tops[0] ? (champById[tops[0].championId] ?? tops[0].championName) : null;
   const mainSplash    = mainChampName ? championSplashUrl(mainChampName, 0) : null;
 
-  // isLinked: verifica via puuid (fonte de verdade) se conta está vinculada no ArenaGG
+  // Busca conta vinculada no ArenaGG via puuid (fonte de verdade)
   const supabase = await createClient();
   const { data: riotRows } = await supabase
     .from("riot_accounts")
     .select(`puuid, players ( id ), profiles ( full_name )`)
     .eq("puuid", puuid)
     .limit(1);
-  const riotRow  = riotRows?.[0] ?? null;
-  const isLinked = !!(riotRow?.players);
+  const riotRow = riotRows?.[0] ?? null;
+  // linkedProfileName: nome do perfil ArenaGG vinculado, ou null se não vinculado
+  const linkedProfileName: string | null = (riotRow?.profiles as any)?.full_name ?? null;
 
   const myMatches = matches
     .map((m) => ({ match: m, me: m.info.participants.find((p: MatchParticipant) => p.puuid === puuid) }))
@@ -118,8 +117,7 @@ export default async function PlayerProfilePage({
         totalLosses={totalLosses}
         recentWR={recentWR}
         avgKDA={avgKDA}
-        profileName={(riotRow?.profiles as any)?.full_name ?? null}
-        isLinked={isLinked}
+        linkedProfileName={linkedProfileName}
       />
 
       {/* CORPO */}
@@ -183,7 +181,6 @@ export default async function PlayerProfilePage({
                   gameDuration={match.info.gameDuration}
                   gameStartTimestamp={match.info.gameStartTimestamp}
                   pentaKills={me!.pentaKills}
-                  // ddVersion removido — PR14
                   champById={champById}
                 />
               ))}

--- a/app/jogadores/[gameName]/[tagLine]/page.tsx
+++ b/app/jogadores/[gameName]/[tagLine]/page.tsx
@@ -11,6 +11,7 @@ import { HeroBanner }   from "@/components/profile/HeroBanner";
 import { RankCard }     from "@/components/profile/RankCard";
 import { MasteryGrid }  from "@/components/profile/MasteryGrid";
 import { MatchRow }     from "@/components/profile/MatchRow";
+import { ClipboardList, Gamepad2 } from "lucide-react";
 
 export const maxDuration = 60;
 
@@ -99,17 +100,7 @@ export default async function PlayerProfilePage({
     : "0.00";
 
   return (
-    <div className="min-h-screen bg-[#050E1A]">
-      <style>{`
-        .match-row:hover { background: rgba(30,58,95,0.4) !important; }
-        .stat-pill {
-          display:inline-flex; align-items:center; gap:4px;
-          background:rgba(200,168,75,0.1); border:1px solid rgba(200,168,75,0.25);
-          border-radius:9999px; padding:3px 10px; font-size:12px; color:#C8A84B;
-          font-weight:600; white-space:nowrap;
-        }
-      `}</style>
-
+    <div className="min-h-screen" style={{ background: "var(--bg)" }}>
       {/* HERO BANNER — componente isolado */}
       <HeroBanner
         gameName={account.gameName}
@@ -131,7 +122,7 @@ export default async function PlayerProfilePage({
       {/* CORPO */}
       <div className="max-w-6xl mx-auto px-4 py-6 space-y-6">
 
-        {/* RANK CARDS — componente isolado, sem border-left colorido */}
+        {/* RANK CARDS */}
         {(rankSolo || rankFlex) && (
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 16 }}>
             {[rankSolo, rankFlex].filter(Boolean).map((r) => (
@@ -140,15 +131,35 @@ export default async function PlayerProfilePage({
           </div>
         )}
 
-        {/* MAESTRIA — componente isolado */}
+        {/* MAESTRIA */}
         <MasteryGrid masteries={tops} champById={champById} />
 
-        {/* HISTÓRICO — componente MatchRow isolado por partida */}
+        {/* HISTÓRICO */}
         {myMatches.length > 0 && (
-          <div style={{ background: "#0A1428", border: "1px solid rgba(30,58,95,0.8)", borderRadius: 16, overflow: "hidden" }}>
-            <div style={{ padding: "16px 20px 12px", borderBottom: "1px solid rgba(30,58,95,0.6)" }}>
-              <p style={{ color: "#9CA3AF", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em" }}>
-                📋 Histórico Recente ({myMatches.length} partidas)
+          <div
+            className="card"
+            style={{ padding: 0, overflow: "hidden", borderRadius: "var(--radius-lg)" }}
+          >
+            <div
+              style={{
+                padding: "16px 20px 12px",
+                borderBottom: "1px solid var(--border-soft, rgba(30,58,95,0.5))",
+              }}
+            >
+              <p
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  color: "var(--text-muted)",
+                  fontSize: "var(--text-xs)",
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                }}
+              >
+                <ClipboardList size={13} />
+                Histórico Recente ({myMatches.length} partidas)
               </p>
             </div>
             <div>
@@ -177,22 +188,41 @@ export default async function PlayerProfilePage({
           </div>
         )}
 
-        {/* EMPTY STATE */}
+        {/* EMPTY STATE — sem partidas recentes */}
         {totalGames === 0 && (
-          <div style={{ textAlign: "center", padding: "60px 20px" }}>
+          <div className="card text-center" style={{ padding: "60px 20px" }}>
             <div
+              className="mx-auto mb-4 flex items-center justify-center animate-float"
               style={{
-                width: 64, height: 64, borderRadius: 16,
-                background: "rgba(200,168,75,0.08)",
-                border: "1px solid rgba(200,168,75,0.2)",
-                display: "flex", alignItems: "center", justifyContent: "center",
-                margin: "0 auto 16px", fontSize: 28,
+                width: 64,
+                height: 64,
+                borderRadius: "var(--radius-xl)",
+                background: "var(--gold-dim, rgba(200,168,75,0.08))",
+                border: "1px solid var(--border-gold, rgba(200,168,75,0.2))",
+                color: "var(--gold)",
               }}
             >
-              🎮
+              <Gamepad2 size={28} />
             </div>
-            <p style={{ fontSize: 16, fontWeight: 600, color: "#D1D5DB" }}>Nenhuma partida recente encontrada</p>
-            <p style={{ fontSize: 13, color: "#4B5563", marginTop: 6 }}>Os dados são atualizados automaticamente.</p>
+            <p
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: "var(--text-base)",
+                fontWeight: 600,
+                color: "var(--text)",
+                marginBottom: "var(--sp-2)",
+              }}
+            >
+              Nenhuma partida recente encontrada
+            </p>
+            <p
+              style={{
+                fontSize: "var(--text-sm)",
+                color: "var(--text-muted)",
+              }}
+            >
+              Os dados são atualizados automaticamente.
+            </p>
           </div>
         )}
       </div>

--- a/app/jogadores/[gameName]/[tagLine]/page.tsx
+++ b/app/jogadores/[gameName]/[tagLine]/page.tsx
@@ -3,7 +3,8 @@ import {
   getAccountByRiotId, getSummonerByPuuid, getLeagueEntriesByPuuid,
   getTopMasteriesByPuuid, getMatchIdsByPuuid, getMatchById,
   getAllChampions, profileIconUrl, profileIconBorderStyle,
-  profileBorderUrl, championSplashUrl, getDDVersion,
+  profileBorderUrl, championSplashUrl,
+  // getDDVersion removido — PR14: MatchRow usa versão pinada internamente
 } from "@/lib/riot";
 import { createClient } from "@/lib/supabase/server";
 import type { MatchParticipant } from "@/lib/riot";
@@ -66,7 +67,7 @@ export default async function PlayerProfilePage({
     .filter((r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof getMatchById>>> => r.status === "fulfilled")
     .map((r) => r.value);
 
-  const ddVersion   = await getDDVersion();
+  // getDDVersion removido — PR14: MatchRow encapsula versão de CDN internamente
   const iconUrl     = sum ? await profileIconUrl(sum.profileIconId) : null;
   const level       = sum?.summonerLevel ?? 0;
   const borderStyle = profileIconBorderStyle(level);
@@ -78,14 +79,15 @@ export default async function PlayerProfilePage({
   const mainChampName = tops[0] ? (champById[tops[0].championId] ?? tops[0].championName) : null;
   const mainSplash    = mainChampName ? championSplashUrl(mainChampName, 0) : null;
 
+  // isLinked: verifica via puuid (fonte de verdade) se conta está vinculada no ArenaGG
   const supabase = await createClient();
   const { data: riotRows } = await supabase
     .from("riot_accounts")
-    .select(`id, profile_id, profiles ( full_name )`)
-    .ilike("game_name", gameName)
-    .ilike("tag_line",  tagLine)
+    .select(`puuid, players ( id ), profiles ( full_name )`)
+    .eq("puuid", puuid)
     .limit(1);
-  const riotRow = riotRows?.[0] ?? null;
+  const riotRow  = riotRows?.[0] ?? null;
+  const isLinked = !!(riotRow?.players);
 
   const myMatches = matches
     .map((m) => ({ match: m, me: m.info.participants.find((p: MatchParticipant) => p.puuid === puuid) }))
@@ -101,7 +103,7 @@ export default async function PlayerProfilePage({
 
   return (
     <div className="min-h-screen" style={{ background: "var(--bg)" }}>
-      {/* HERO BANNER — componente isolado */}
+      {/* HERO BANNER */}
       <HeroBanner
         gameName={account.gameName}
         tagLine={account.tagLine}
@@ -117,6 +119,7 @@ export default async function PlayerProfilePage({
         recentWR={recentWR}
         avgKDA={avgKDA}
         profileName={(riotRow?.profiles as any)?.full_name ?? null}
+        isLinked={isLinked}
       />
 
       {/* CORPO */}
@@ -180,7 +183,7 @@ export default async function PlayerProfilePage({
                   gameDuration={match.info.gameDuration}
                   gameStartTimestamp={match.info.gameStartTimestamp}
                   pentaKills={me!.pentaKills}
-                  ddVersion={ddVersion}
+                  // ddVersion removido — PR14
                   champById={champById}
                 />
               ))}
@@ -188,7 +191,7 @@ export default async function PlayerProfilePage({
           </div>
         )}
 
-        {/* EMPTY STATE — sem partidas recentes */}
+        {/* EMPTY STATE */}
         {totalGames === 0 && (
           <div className="card text-center" style={{ padding: "60px 20px" }}>
             <div
@@ -215,12 +218,7 @@ export default async function PlayerProfilePage({
             >
               Nenhuma partida recente encontrada
             </p>
-            <p
-              style={{
-                fontSize: "var(--text-sm)",
-                color: "var(--text-muted)",
-              }}
-            >
+            <p style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>
               Os dados são atualizados automaticamente.
             </p>
           </div>

--- a/app/jogadores/loading.tsx
+++ b/app/jogadores/loading.tsx
@@ -1,0 +1,59 @@
+export default function JogadoresLoading() {
+  return (
+    <main
+      className="min-h-screen"
+      style={{
+        background: 'var(--bg)',
+        paddingTop: 'var(--sp-10)',
+        paddingBottom: 'var(--sp-10)',
+        paddingInline: 'var(--sp-4)',
+      }}
+    >
+      <div style={{ maxWidth: 'var(--content-default)', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 'var(--sp-8)' }}>
+
+        {/* Cabeçalho skeleton */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
+          <div className="skeleton" style={{ height: 32, width: 180, borderRadius: 'var(--radius-sm)' }} />
+          <div className="skeleton" style={{ height: 16, width: 120, borderRadius: 'var(--radius-sm)' }} />
+        </div>
+
+        {/* Filtros skeleton */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-3)' }}>
+          <div className="skeleton" style={{ height: 38, width: 320, borderRadius: 'var(--radius-md)' }} />
+          <div style={{ display: 'flex', gap: 'var(--sp-2)', flexWrap: 'wrap' }}>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="skeleton" style={{ height: 28, width: 60 + i * 8, borderRadius: 'var(--radius-full)' }} />
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 'var(--sp-2)', flexWrap: 'wrap' }}>
+            {Array.from({ length: 11 }).map((_, i) => (
+              <div key={i} className="skeleton" style={{ height: 28, width: 64, borderRadius: 'var(--radius-full)' }} />
+            ))}
+          </div>
+        </div>
+
+        {/* Lista skeleton */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="card-sm"
+              style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-4)' }}
+            >
+              <div className="skeleton" style={{ width: 24, height: 16, borderRadius: 'var(--radius-sm)', flexShrink: 0 }} />
+              <div className="skeleton" style={{ width: 40, height: 40, borderRadius: 'var(--radius-full)', flexShrink: 0 }} />
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
+                <div className="skeleton" style={{ height: 14, width: `${140 + (i % 3) * 30}px`, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 12, width: 80, borderRadius: 'var(--radius-sm)' }} />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-1)', alignItems: 'flex-end' }}>
+                <div className="skeleton" style={{ height: 14, width: 80, borderRadius: 'var(--radius-sm)' }} />
+                <div className="skeleton" style={{ height: 12, width: 48, borderRadius: 'var(--radius-sm)' }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/jogadores/page.tsx
+++ b/app/jogadores/page.tsx
@@ -1,19 +1,27 @@
 import { createClient } from '@/lib/supabase/server';
 import Link from 'next/link';
+import { Gamepad2, Shield } from 'lucide-react';
 
 const TIER_COLORS: Record<string, string> = {
-  CHALLENGER: 'text-yellow-300',
+  CHALLENGER:  'text-yellow-300',
   GRANDMASTER: 'text-red-400',
-  MASTER: 'text-purple-400',
-  DIAMOND: 'text-blue-400',
-  EMERALD: 'text-emerald-400',
-  PLATINUM: 'text-teal-400',
-  GOLD: 'text-yellow-500',
-  SILVER: 'text-gray-400',
-  BRONZE: 'text-orange-700',
-  IRON: 'text-gray-500',
-  UNRANKED: 'text-gray-600',
+  MASTER:      'text-purple-400',
+  DIAMOND:     'text-blue-400',
+  EMERALD:     'text-emerald-400',
+  PLATINUM:    'text-teal-400',
+  GOLD:        'text-yellow-500',
+  SILVER:      'text-gray-400',
+  BRONZE:      'text-orange-700',
+  IRON:        'text-gray-500',
+  UNRANKED:    'text-gray-600',
 };
+
+/* winrate inline color usando tokens CSS */
+function winrateColor(wr: number): string {
+  if (wr >= 60) return 'var(--win)';
+  if (wr >= 50) return 'var(--gold)';
+  return 'var(--loss)';
+}
 
 const TIER_EMBLEMS: Record<string, string> = {
   CHALLENGER:  'https://raw.communitydragon.org/latest/plugins/rcp-fe-lol-shared-components/global/default/images/ranked-emblems/emblem-challenger.png',
@@ -59,7 +67,6 @@ export default async function JogadoresPage({
   const { role, tier, q } = await searchParams;
   const supabase = await createClient();
 
-  // Fix 3: removido team_id e teams(id, name, tag) — coluna team_id foi dropada na migration
   let query = supabase
     .from('players')
     .select('id, summoner_name, tag_line, role, tier, rank, lp, wins, losses, puuid')
@@ -74,10 +81,6 @@ export default async function JogadoresPage({
   const roles = ['top', 'jungle', 'mid', 'adc', 'support'];
   const tiers = ['CHALLENGER','GRANDMASTER','MASTER','DIAMOND','EMERALD','PLATINUM','GOLD','SILVER','BRONZE','IRON'];
 
-  const btnBase     = 'px-3 py-1 rounded text-xs border transition-colors';
-  const btnActive   = 'border-[#C8A84B] text-[#C8A84B] bg-[#C8A84B]/10';
-  const btnInactive = 'border-[#1E3A5F] text-gray-400 hover:border-[#C8A84B]/50';
-
   function buildQuery(patch: Record<string, string | undefined>) {
     const params = new URLSearchParams();
     if (role) params.set('role', role);
@@ -90,19 +93,48 @@ export default async function JogadoresPage({
     return '/jogadores' + (str ? '?' + str : '');
   }
 
-  return (
-    <main className="min-h-screen bg-[#050E1A] py-10 px-4">
-      <div className="max-w-5xl mx-auto space-y-8">
+  /* estilos de botão de filtro via tokens CSS */
+  const filterBtnBase: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '4px 12px',
+    borderRadius: 'var(--radius-full)',
+    fontSize: 'var(--text-xs)',
+    fontWeight: 600,
+    fontFamily: 'var(--font-display)',
+    border: '1px solid var(--border)',
+    color: 'var(--text-muted)',
+    background: 'transparent',
+    transition: 'border-color var(--ease-ui), color var(--ease-ui), background var(--ease-ui)',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap' as const,
+    cursor: 'pointer',
+  };
+  const filterBtnActive: React.CSSProperties = {
+    ...filterBtnBase,
+    border: '1px solid var(--border-gold)',
+    color: 'var(--gold)',
+    background: 'var(--gold-dim)',
+  };
 
+  return (
+    <main className="min-h-screen" style={{ background: 'var(--bg)', paddingTop: 'var(--sp-10)', paddingBottom: 'var(--sp-10)', paddingInline: 'var(--sp-4)' }}>
+      <div style={{ maxWidth: 'var(--content-default)', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 'var(--sp-8)' }}>
+
+        {/* Cabeçalho */}
         <div>
-          <h1 className="text-3xl font-bold text-white">Jogadores</h1>
-          <p className="text-gray-400 text-sm mt-1">
+          <h1 style={{ fontFamily: 'var(--font-display)', fontSize: 'var(--text-xl)', fontWeight: 800, color: 'var(--text)' }}>
+            Jogadores
+          </h1>
+          <p style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)', marginTop: 'var(--sp-1)' }}>
             {players?.length ?? 0} jogador{players?.length !== 1 ? 'es' : ''} encontrado{players?.length !== 1 ? 's' : ''}
           </p>
         </div>
 
         {/* Filtros */}
-        <div className="space-y-3">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-3)' }}>
+
+          {/* Busca */}
           <form method="GET" action="/jogadores">
             {role && <input type="hidden" name="role" value={role} />}
             {tier && <input type="hidden" name="tier" value={tier} />}
@@ -110,25 +142,33 @@ export default async function JogadoresPage({
               name="q"
               defaultValue={q}
               placeholder="Buscar por summoner name..."
-              className="w-full md:w-80 bg-[#0D1B2E] border border-[#1E3A5F] rounded px-3 py-2 text-white text-sm placeholder-gray-500 focus:border-[#C8A84B] outline-none"
+              className="input-lol"
+              style={{ maxWidth: 320 }}
             />
           </form>
 
-          <div className="flex items-center flex-wrap gap-2">
-            <span className="text-xs text-gray-500 mr-1">Role:</span>
-            <Link href={buildQuery({ role: undefined })} className={`${btnBase} ${!role ? btnActive : btnInactive}`}>Todos</Link>
+          {/* Filtro Role */}
+          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--sp-2)' }}>
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-faint)', marginRight: 'var(--sp-1)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Role:</span>
+            <Link href={buildQuery({ role: undefined })} style={!role ? filterBtnActive : filterBtnBase}>Todos</Link>
             {roles.map((r) => (
-              <Link key={r} href={buildQuery({ role: r })} className={`${btnBase} ${role === r ? btnActive : btnInactive}`}>
+              <Link key={r} href={buildQuery({ role: r })} style={role === r ? filterBtnActive : filterBtnBase}>
                 {ROLE_LABELS[r] ?? r}
               </Link>
             ))}
           </div>
 
-          <div className="flex items-center flex-wrap gap-2">
-            <span className="text-xs text-gray-500 mr-1">Tier:</span>
-            <Link href={buildQuery({ tier: undefined })} className={`${btnBase} ${!tier ? btnActive : btnInactive}`}>Todos</Link>
+          {/* Filtro Tier */}
+          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--sp-2)' }}>
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-faint)', marginRight: 'var(--sp-1)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Tier:</span>
+            <Link href={buildQuery({ tier: undefined })} style={!tier ? filterBtnActive : filterBtnBase}>Todos</Link>
             {tiers.map((t) => (
-              <Link key={t} href={buildQuery({ tier: t })} className={`${btnBase} ${tier?.toUpperCase() === t ? btnActive : btnInactive} ${TIER_COLORS[t]}`}>
+              <Link
+                key={t}
+                href={buildQuery({ tier: t })}
+                className={TIER_COLORS[t]}
+                style={tier?.toUpperCase() === t ? { ...filterBtnActive } : { ...filterBtnBase }}
+              >
                 {t[0] + t.slice(1).toLowerCase()}
               </Link>
             ))}
@@ -137,12 +177,30 @@ export default async function JogadoresPage({
 
         {/* Lista */}
         {(players ?? []).length === 0 ? (
-          <div className="text-center py-16">
-            <p className="text-4xl mb-3">🎮</p>
-            <p className="text-gray-500 text-sm">Nenhum jogador encontrado.</p>
+          <div style={{ textAlign: 'center', padding: 'var(--sp-16) var(--sp-8)' }}>
+            <div
+              className="mx-auto mb-4 flex items-center justify-center"
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: 'var(--radius-xl)',
+                background: 'var(--gold-dim)',
+                border: '1px solid var(--border-gold)',
+                color: 'var(--gold)',
+                margin: '0 auto var(--sp-4)',
+              }}
+            >
+              <Gamepad2 size={24} />
+            </div>
+            <p style={{ fontFamily: 'var(--font-display)', fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--text)', marginBottom: 'var(--sp-2)' }}>
+              Nenhum jogador encontrado.
+            </p>
+            <p style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+              Tente ajustar os filtros ou a busca.
+            </p>
           </div>
         ) : (
-          <div className="grid gap-3">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
             {(players ?? []).map((player, idx) => {
               const total   = (player.wins ?? 0) + (player.losses ?? 0);
               const winrate = total > 0 ? Math.round(((player.wins ?? 0) / total) * 100) : null;
@@ -157,60 +215,90 @@ export default async function JogadoresPage({
               const displayTag  = riotId?.tagLine  ?? player.tag_line      ?? '';
 
               const cardContent = (
-                <div className="bg-[#0D1B2E] border border-[#1E3A5F] rounded-lg p-4 flex items-center gap-4 hover:border-[#C8A84B]/40 hover:bg-[#0F2035] transition-all group">
-                  <span className="text-gray-600 text-sm w-6 text-right flex-shrink-0 font-mono">{idx + 1}</span>
+                <div
+                  className="card-sm group"
+                  style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-4)' }}
+                >
+                  {/* Número ranking */}
+                  <span style={{
+                    fontSize: 'var(--text-xs)',
+                    color: 'var(--text-faint)',
+                    width: 24,
+                    textAlign: 'right',
+                    flexShrink: 0,
+                    fontVariantNumeric: 'tabular-nums',
+                    fontWeight: 600,
+                  }}>
+                    {idx + 1}
+                  </span>
 
-                  <div className="w-10 h-10 flex-shrink-0 flex items-center justify-center">
+                  {/* Emblema tier */}
+                  <div style={{ width: 40, height: 40, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     {emblem ? (
-                      <img src={emblem} width={40} height={40} alt={player.tier ?? ''} className="w-10 h-10 object-contain" />
+                      <img src={emblem} width={40} height={40} alt={player.tier ?? ''} loading="lazy" style={{ width: 40, height: 40, objectFit: 'contain' }} />
                     ) : (
-                      <div className="w-8 h-8 rounded-full bg-[#1E3A5F]/50 flex items-center justify-center">
-                        <span className="text-gray-600 text-xs">🎮</span>
+                      <div style={{
+                        width: 32, height: 32, borderRadius: 'var(--radius-full)',
+                        background: 'var(--surface-3)', border: '1px solid var(--border-soft)',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        color: 'var(--text-faint)',
+                      }}>
+                        <Shield size={14} />
                       </div>
                     )}
                   </div>
 
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-white font-semibold text-sm group-hover:text-[#C8A84B] transition-colors">
+                  {/* Nome + tag + role */}
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', flexWrap: 'wrap' }}>
+                      <span style={{
+                        fontSize: 'var(--text-sm)',
+                        fontWeight: 600,
+                        color: 'var(--text)',
+                        fontFamily: 'var(--font-display)',
+                        transition: 'color var(--ease-ui)',
+                      }} className="group-hover:text-[var(--gold)]">
                         {displayName}
                       </span>
                       {displayTag && (
-                        <span className="text-gray-500 text-xs">#{displayTag}</span>
+                        <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-faint)' }}>#{displayTag}</span>
                       )}
                       {player.role && (
-                        <span className="text-xs text-[#C8A84B] bg-[#C8A84B]/10 border border-[#C8A84B]/20 rounded px-1.5 py-0.5">
+                        <span className="badge-gold" style={{ fontSize: '0.65rem' }}>
                           {ROLE_LABELS[player.role] ?? player.role}
                         </span>
                       )}
                     </div>
                   </div>
 
-                  <div className="text-right flex-shrink-0">
+                  {/* Tier + LP */}
+                  <div style={{ textAlign: 'right', flexShrink: 0 }}>
                     <p className={`text-sm font-semibold ${TIER_COLORS[player.tier ?? 'UNRANKED']}`}>
                       {player.tier ?? 'UNRANKED'} {player.rank ?? ''}
                     </p>
                     {player.lp != null && (
-                      <p className="text-xs text-gray-400">{player.lp} LP</p>
+                      <p style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{player.lp} LP</p>
                     )}
                   </div>
 
-                  <div className="text-right flex-shrink-0 hidden sm:block min-w-[64px]">
+                  {/* Winrate — oculto em mobile */}
+                  <div style={{ textAlign: 'right', flexShrink: 0, minWidth: 64 }} className="hidden sm:block">
                     {winrate !== null ? (
                       <>
-                        <p className="text-xs text-white">{player.wins}V {player.losses}D</p>
-                        <p className={`text-xs font-semibold ${
-                          winrate >= 60 ? 'text-green-400' : winrate >= 50 ? 'text-yellow-400' : 'text-red-400'
-                        }`}>{winrate}% WR</p>
+                        <p style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{player.wins}V {player.losses}D</p>
+                        <p style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: winrateColor(winrate) }}>
+                          {winrate}% WR
+                        </p>
                       </>
                     ) : (
-                      <p className="text-xs text-gray-600">—</p>
+                      <p style={{ fontSize: 'var(--text-xs)', color: 'var(--text-faint)' }}>—</p>
                     )}
                   </div>
 
+                  {/* CTA */}
                   {href && (
-                    <div className="flex-shrink-0">
-                      <span className="inline-flex items-center gap-1 text-xs font-semibold text-[#C8A84B] bg-[#C8A84B]/10 border border-[#C8A84B]/30 rounded-lg px-3 py-1.5 group-hover:bg-[#C8A84B]/20 transition-colors whitespace-nowrap">
+                    <div style={{ flexShrink: 0 }}>
+                      <span className="badge-gold" style={{ fontSize: 'var(--text-xs)', whiteSpace: 'nowrap' }}>
                         Ver Perfil →
                       </span>
                     </div>
@@ -219,7 +307,7 @@ export default async function JogadoresPage({
               );
 
               return href ? (
-                <Link key={player.id} href={href} className="block">
+                <Link key={player.id} href={href} style={{ display: 'block', textDecoration: 'none' }}>
                   {cardContent}
                 </Link>
               ) : (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,37 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Navbar } from "@/components/layout/Navbar";
+
 export const metadata: Metadata = {
-  title: "LoL Tournament BR",
-  description: "Torneios casuais de League of Legends 5x5",
+  title: {
+    default: "ArenaGG — Torneios de League of Legends BR",
+    template: "%s — ArenaGG",
+  },
+  description: "Cadastre seu invocador, monte seu time e dispute torneios 5v5 de League of Legends com bracket, stats reais e ranking oficial Riot.",
+  keywords: ["league of legends", "torneio", "lol", "brasil", "ranked", "5v5"],
+  openGraph: {
+    type: "website",
+    locale: "pt_BR",
+    siteName: "ArenaGG",
+    title: "ArenaGG — Torneios de League of Legends BR",
+    description: "Cadastre seu invocador, monte seu time e dispute torneios 5v5 com bracket, stats reais e ranking oficial Riot.",
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
 };
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt-BR">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@300;400;500;600&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body className="min-h-screen">
         <Navbar />
         <main className="max-w-7xl mx-auto px-4 py-6">{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { TournamentCard } from "@/components/tournament/TournamentCard";
+import { StatsSection } from "@/components/home/StatsSection";
+import { HowItWorks } from "@/components/home/HowItWorks";
+import { HeroSection } from "@/components/home/HeroSection";
 
 export default async function HomePage() {
   const supabase = await createClient();
 
-  // FIX: start_date nao existe como coluna de ordenacao — usar starts_at
   const { data: tournaments } = await supabase
     .from("tournaments")
     .select("*")
@@ -27,76 +29,85 @@ export default async function HomePage() {
 
   return (
     <div className="space-y-16">
-      <section className="relative rounded-2xl overflow-hidden min-h-[380px] flex items-center">
-        <div className="absolute inset-0 bg-gradient-to-r from-[#050D1A] via-[#0A1428]/95 to-transparent z-10" />
-        <div className="absolute inset-0 bg-cover bg-center opacity-30"
-          style={{ backgroundImage: "url('https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/loadingscreen/summoners-rift.jpg')" }} />
-        <div className="relative z-20 p-8 md:p-16 max-w-2xl">
-          <span className="text-[#C8A84B] font-bold tracking-widest text-xs uppercase mb-3 block">
-            Summoner's Rift 5v5 Casual
-          </span>
-          <h1 className="text-4xl md:text-6xl font-bold text-white mb-4 leading-tight">
-            Torneios de<br /><span className="text-[#C8A84B]">League of Legends</span>
-          </h1>
-          <p className="text-gray-300 text-lg mb-8">
-            Cadastre seu invocador, monte seu time e dispute torneios com bracket, stats reais e ranking oficial Riot.
-          </p>
-          <div className="flex gap-4 flex-wrap">
-            <Link href="/torneios" className="btn-gold text-base px-8 py-3">Ver Torneios</Link>
-            <Link href="/dashboard/jogador/registrar" className="btn-outline-gold text-base px-8 py-3">Cadastrar Invocador</Link>
-          </div>
-        </div>
-      </section>
+      {/* Hero — Client Component com Framer Motion */}
+      <HeroSection />
 
-      <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {[
-          { label: "Invocadores", value: totalPlayers ?? 0, icon: "👤" },
-          { label: "Times",       value: totalTeams   ?? 0, icon: "🛡️" },
-          { label: "Torneios",    value: totalT        ?? 0, icon: "🏆" },
-          { label: "Mapa",        value: "SR 5v5",          icon: "🗺️" },
-        ].map(s => (
-          <div key={s.label} className="card-lol text-center py-6">
-            <p className="text-3xl mb-2">{s.icon}</p>
-            <p className="text-2xl font-bold text-[#C8A84B]">{s.value}</p>
-            <p className="text-gray-400 text-sm mt-1">{s.label}</p>
-          </div>
-        ))}
-      </section>
+      {/* Stats — Client Component com stagger animation */}
+      <StatsSection
+        totalPlayers={totalPlayers ?? 0}
+        totalTeams={totalTeams ?? 0}
+        totalTournaments={totalT ?? 0}
+      />
 
-      <section>
-        <h2 className="text-2xl font-bold text-white mb-8 text-center">Como funciona</h2>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-          {[
-            { step:"01", title:"Cadastre-se",   desc:"Crie sua conta e vincule seu Riot ID.", icon:"👤" },
-            { step:"02", title:"Monte seu Time", desc:"Crie time 5v5 e convide seus amigos.",  icon:"🛡️" },
-            { step:"03", title:"Inscreva-se",    desc:"Encontre torneio aberto e inscreva.",   icon:"📋" },
-            { step:"04", title:"Dispute",         desc:"Jogue, reporte resultados e veja o bracket.", icon:"⚔️" },
-          ].map(i => (
-            <div key={i.step} className="card-lol text-center">
-              <p className="text-4xl mb-3">{i.icon}</p>
-              <span className="text-[#C8A84B] text-xs font-bold tracking-widest">PASSO {i.step}</span>
-              <h3 className="text-white font-bold text-lg mt-1 mb-2">{i.title}</h3>
-              <p className="text-gray-400 text-sm">{i.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+      {/* Como funciona — Client Component com stagger animation */}
+      <HowItWorks />
 
+      {/* Torneios Ativos */}
       <section>
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-white">Torneios Ativos</h2>
-          <Link href="/torneios" className="text-[#C8A84B] hover:underline text-sm">Ver todos →</Link>
+          <h2
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: "var(--text-xl)",
+              color: "var(--text)",
+            }}
+          >
+            Torneios Ativos
+          </h2>
+          <Link
+            href="/torneios"
+            style={{ color: "var(--gold)", fontSize: "var(--text-sm)" }}
+            className="hover:underline transition-opacity"
+          >
+            Ver todos →
+          </Link>
         </div>
+
         {tournaments && tournaments.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {tournaments.map(t => <TournamentCard key={t.id} tournament={t} />)}
+            {tournaments.map((t) => (
+              <TournamentCard key={t.id} tournament={t} />
+            ))}
           </div>
         ) : (
-          <div className="card-lol text-center py-16">
-            <p className="text-4xl mb-4">🏆</p>
-            <p className="text-white font-semibold text-lg mb-2">Nenhum torneio ativo no momento</p>
-            <p className="text-gray-400 text-sm mb-6">Em breve novos torneios serão abertos para inscrição.</p>
-            <Link href="/torneios" className="btn-outline-gold">Ver todos os torneios</Link>
+          <div className="card text-center py-16">
+            <div
+              className="mx-auto mb-4 flex items-center justify-center animate-float"
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: "var(--radius-xl)",
+                background: "var(--gold-dim)",
+                border: "1px solid var(--border-gold)",
+                color: "var(--gold)",
+                fontSize: 28,
+              }}
+            >
+              🏆
+            </div>
+            <p
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: "var(--text-lg)",
+                color: "var(--text)",
+                fontWeight: 700,
+                marginBottom: "var(--sp-2)",
+              }}
+            >
+              Nenhum torneio ativo no momento
+            </p>
+            <p
+              style={{
+                fontSize: "var(--text-sm)",
+                color: "var(--text-muted)",
+                marginBottom: "var(--sp-6)",
+              }}
+            >
+              Em breve novos torneios serão abertos para inscrição.
+            </p>
+            <Link href="/torneios" className="btn-outline-gold">
+              Ver todos os torneios
+            </Link>
           </div>
         )}
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Trophy } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { TournamentCard } from "@/components/tournament/TournamentCard";
 import { StatsSection } from "@/components/home/StatsSection";
@@ -77,13 +78,12 @@ export default async function HomePage() {
                 width: 56,
                 height: 56,
                 borderRadius: "var(--radius-xl)",
-                background: "var(--gold-dim)",
-                border: "1px solid var(--border-gold)",
+                background: "var(--gold-dim, rgba(200,168,75,0.08))",
+                border: "1px solid var(--border-gold, rgba(200,168,75,0.2))",
                 color: "var(--gold)",
-                fontSize: 28,
               }}
             >
-              🏆
+              <Trophy size={24} />
             </div>
             <p
               style={{

--- a/app/profile/[summonerName]/page.tsx
+++ b/app/profile/[summonerName]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { notFound } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
 import ProfileHeader from '@/components/profile/ProfileHeader';
 import RankedCards from '@/components/profile/RankedCards';
 import MatchHistoryRow from '@/components/profile/MatchHistoryRow';
@@ -28,11 +29,25 @@ export default async function ProfilePage({
   const data = await getPlayerProfile(summonerName);
   if (!data) return notFound();
 
+  // DD_VERSION ainda usado por MatchHistoryRow e ChampionStatsTable (migração futura)
   const DD_VERSION = await getDDVersion();
   const topChamp = data.topMasteries?.[0]?.championName;
   const splashUrl = championSplashUrl(topChamp);
 
-  // Calcula estatísticas agregadas por campeão
+  // isLinked: verifica se existe riot_account com puuid vinculado a um player no ArenaGG
+  // puuid é a fonte de verdade para identidade de conta (não summonerName)
+  let isLinked = false;
+  if (data.puuid) {
+    const supabase = await createClient();
+    const { data: riotAccount } = await supabase
+      .from('riot_accounts')
+      .select('puuid, players(id)')
+      .eq('puuid', data.puuid)
+      .maybeSingle();
+    isLinked = !!(riotAccount?.players);
+  }
+
+  // Estatísticas agregadas por campeão
   const champStats: Record<string, { games: number; wins: number; kills: number; deaths: number; assists: number }> = {};
   if (data.matchHistory) {
     for (const m of data.matchHistory) {
@@ -61,26 +76,27 @@ export default async function ProfilePage({
     .slice(0, 5);
 
   return (
-    <main className="min-h-screen bg-[#0A0E17]">
+    <main style={{ minHeight: '100vh', background: 'var(--bg)' }}>
       {/* Banner top */}
       <div className="h-64 w-full relative overflow-hidden">
         {splashUrl ? (
           <>
             <img
               src={splashUrl}
-              alt="Background"
+              alt="Background do campeão"
               className="w-full h-full object-cover object-[center_20%] opacity-40 blur-sm scale-105"
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-[#0A0E17] via-transparent to-transparent" />
-            <div className="absolute inset-0 bg-gradient-to-r from-[#0A0E17] via-transparent to-[#0A0E17]" />
+            <div className="absolute inset-0" style={{ background: 'linear-gradient(to top, var(--bg), transparent)' }} />
+            <div className="absolute inset-0" style={{ background: 'linear-gradient(to right, var(--bg), transparent, var(--bg))' }} />
           </>
         ) : (
-          <div className="h-full w-full bg-gradient-to-r from-[#0D1B2E] via-[#091528] to-[#0D1B2E]" />
+          <div className="h-full w-full" style={{ background: 'linear-gradient(to right, var(--surface-2), var(--surface), var(--surface-2))' }} />
         )}
-        <div className="absolute inset-0 opacity-10"
+        <div
+          className="absolute inset-0 opacity-10"
           style={{
-            backgroundImage: 'repeating-linear-gradient(45deg, #C89B3C 0, #C89B3C 1px, transparent 0, transparent 50%)',
-            backgroundSize: '20px 20px'
+            backgroundImage: 'repeating-linear-gradient(45deg, var(--gold) 0, var(--gold) 1px, transparent 0, transparent 50%)',
+            backgroundSize: '20px 20px',
           }}
         />
       </div>
@@ -92,7 +108,7 @@ export default async function ProfilePage({
           tagLine={data.tagLine}
           profileIconId={data.profileIconId}
           summonerLevel={data.summonerLevel}
-          DD_VERSION={DD_VERSION}
+          isLinked={isLinked}
         />
 
         {/* Ranked cards */}
@@ -105,18 +121,29 @@ export default async function ProfilePage({
           {/* Coluna Lateral: Maestrias e stats */}
           <div className="space-y-6">
             <div>
-              <h3 className="text-[#A0AEC0] text-xs font-semibold uppercase tracking-widest mb-3 px-1">Top Maestrias</h3>
-              <div className="bg-[#0D1421] border border-[#1E2D45] rounded-xl p-3 space-y-3">
+              <h3 style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 'var(--sp-3)', paddingInline: 'var(--sp-1)' }}>
+                Top Maestrias
+              </h3>
+              <div className="card-sm space-y-3">
                 {data.topMasteries?.map((m: any) => (
                   <div key={m.championId} className="flex items-center gap-3">
+                    {/* CommunityDragon — padrão do projeto */}
                     <img
-                      src={`https://ddragon.leagueoflegends.com/cdn/${DD_VERSION}/img/champion/${m.championName}.png`}
+                      src={`https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/${m.championId}.png`}
                       alt={m.championName}
-                      className="w-10 h-10 rounded border border-[#C89B3C]/30"
+                      width={40}
+                      height={40}
+                      loading="lazy"
+                      className="rounded"
+                      style={{ border: '1px solid var(--border-gold)' }}
                     />
                     <div className="flex-1 min-w-0">
-                      <p className="text-white text-sm font-bold truncate">{m.championName}</p>
-                      <p className="text-[#718096] text-[10px] uppercase">Nv. {m.masteryLevel} · {m.masteryPoints.toLocaleString()} pts</p>
+                      <p style={{ color: 'var(--text)', fontSize: 'var(--text-sm)', fontWeight: 700 }} className="truncate">
+                        {m.championName}
+                      </p>
+                      <p style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>
+                        Nv. {m.masteryLevel} · {m.masteryPoints.toLocaleString()} pts
+                      </p>
                     </div>
                   </div>
                 ))}
@@ -124,14 +151,18 @@ export default async function ProfilePage({
             </div>
 
             <div>
-              <h3 className="text-[#A0AEC0] text-xs font-semibold uppercase tracking-widest mb-3 px-1">Campeões (últimas 10)</h3>
+              <h3 style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 'var(--sp-3)', paddingInline: 'var(--sp-1)' }}>
+                Campeões (últimas 10)
+              </h3>
               <ChampionStatsTable champions={champList} DD_VERSION={DD_VERSION} />
             </div>
           </div>
 
           {/* Histórico de partidas */}
           <div>
-            <h3 className="text-[#A0AEC0] text-xs font-semibold uppercase tracking-widest mb-3 px-1">Histórico de Partidas</h3>
+            <h3 style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 'var(--sp-3)', paddingInline: 'var(--sp-1)' }}>
+              Histórico de Partidas
+            </h3>
             <div className="space-y-2">
               {data.matchHistory?.length > 0 ? (
                 data.matchHistory.map((match: any) => (
@@ -152,11 +183,11 @@ export default async function ProfilePage({
                   />
                 ))
               ) : (
-                <div className="flex flex-col items-center justify-center py-12 text-[#4A5568]">
-                  <svg width="40" height="40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
+                <div className="flex flex-col items-center justify-center py-12" style={{ color: 'var(--text-faint)' }}>
+                  <svg width="40" height="40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m5-2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
-                  <p className="mt-3 text-sm">Nenhuma partida encontrada.</p>
+                  <p className="mt-3" style={{ fontSize: 'var(--text-sm)' }}>Nenhuma partida encontrada.</p>
                 </div>
               )}
             </div>

--- a/app/profile/[summonerName]/page.tsx
+++ b/app/profile/[summonerName]/page.tsx
@@ -5,7 +5,8 @@ import ProfileHeader from '@/components/profile/ProfileHeader';
 import RankedCards from '@/components/profile/RankedCards';
 import MatchHistoryRow from '@/components/profile/MatchHistoryRow';
 import ChampionStatsTable from '@/components/profile/ChampionStatsTable';
-import { getDDVersion, championSplashUrl } from '@/lib/riot';
+import { championSplashUrl } from '@/lib/riot';
+// getDDVersion removido — MatchHistoryRow e ChampionStatsTable migraram para CommunityDragon (PR13)
 
 async function getPlayerProfile(summonerName: string) {
   try {
@@ -29,13 +30,10 @@ export default async function ProfilePage({
   const data = await getPlayerProfile(summonerName);
   if (!data) return notFound();
 
-  // DD_VERSION ainda usado por MatchHistoryRow e ChampionStatsTable (migração futura)
-  const DD_VERSION = await getDDVersion();
   const topChamp = data.topMasteries?.[0]?.championName;
   const splashUrl = championSplashUrl(topChamp);
 
-  // isLinked: verifica se existe riot_account com puuid vinculado a um player no ArenaGG
-  // puuid é a fonte de verdade para identidade de conta (não summonerName)
+  // isLinked: verifica via puuid (fonte de verdade) se conta está vinculada no ArenaGG
   let isLinked = false;
   if (data.puuid) {
     const supabase = await createClient();
@@ -47,7 +45,7 @@ export default async function ProfilePage({
     isLinked = !!(riotAccount?.players);
   }
 
-  // Estatísticas agregadas por campeão
+  // Estatísticas agregadas por campeão (últimas 10 partidas)
   const champStats: Record<string, { games: number; wins: number; kills: number; deaths: number; assists: number }> = {};
   if (data.matchHistory) {
     for (const m of data.matchHistory) {
@@ -102,7 +100,7 @@ export default async function ProfilePage({
       </div>
 
       <div className="max-w-5xl mx-auto px-4 -mt-20 relative z-10 pb-16">
-        {/* Header: avatar + nome + nível */}
+        {/* Header */}
         <ProfileHeader
           summonerName={data.summonerName}
           tagLine={data.tagLine}
@@ -118,7 +116,7 @@ export default async function ProfilePage({
 
         {/* Grid principal */}
         <div className="mt-8 grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
-          {/* Coluna Lateral: Maestrias e stats */}
+          {/* Coluna lateral: Maestrias + Stats */}
           <div className="space-y-6">
             <div>
               <h3 style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 'var(--sp-3)', paddingInline: 'var(--sp-1)' }}>
@@ -127,7 +125,7 @@ export default async function ProfilePage({
               <div className="card-sm space-y-3">
                 {data.topMasteries?.map((m: any) => (
                   <div key={m.championId} className="flex items-center gap-3">
-                    {/* CommunityDragon — padrão do projeto */}
+                    {/* CommunityDragon por championId — padrão do projeto */}
                     <img
                       src={`https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/${m.championId}.png`}
                       alt={m.championName}
@@ -154,7 +152,8 @@ export default async function ProfilePage({
               <h3 style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 'var(--sp-3)', paddingInline: 'var(--sp-1)' }}>
                 Campeões (últimas 10)
               </h3>
-              <ChampionStatsTable champions={champList} DD_VERSION={DD_VERSION} />
+              {/* DD_VERSION removido — ChampionStatsTable usa CommunityDragon internamente */}
+              <ChampionStatsTable champions={champList} />
             </div>
           </div>
 
@@ -178,8 +177,8 @@ export default async function ProfilePage({
                     gameDuration={match.minutes * 60}
                     cs={match.cs ?? 0}
                     vision={match.vision ?? 0}
-                    DD_VERSION={DD_VERSION}
                     items={match.items}
+                    // DD_VERSION removido — componente usa CommunityDragon (PR13)
                   />
                 ))
               ) : (

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -1,10 +1,11 @@
 "use client";
 import Link from "next/link";
 import { motion } from "framer-motion";
+import { Meteors } from "@/components/ui/meteors";
 
 export function HeroSection() {
   return (
-    <section className="relative rounded-2xl overflow-hidden min-h-[400px] flex items-center">
+    <section className="relative rounded-2xl overflow-hidden min-h-[420px] flex items-center">
       {/* Fundo: imagem do Rift */}
       <div
         className="absolute inset-0 bg-cover bg-center"
@@ -14,10 +15,14 @@ export function HeroSection() {
           opacity: 0.28,
         }}
       />
-      {/* Gradiente overlay */}
+      {/* Gradientes */}
       <div className="absolute inset-0 bg-gradient-to-r from-[#050D1A] via-[#050D1A]/90 to-transparent z-10" />
-      {/* Vinheta lateral */}
       <div className="absolute inset-0 bg-gradient-to-t from-[#050D1A]/60 to-transparent z-10" />
+
+      {/* Meteoros — efeito de partículas douradas */}
+      <div className="absolute inset-0 z-10 overflow-hidden pointer-events-none">
+        <Meteors number={12} />
+      </div>
 
       {/* Conteúdo */}
       <div className="relative z-20 p-8 md:p-16 max-w-2xl">
@@ -25,31 +30,21 @@ export function HeroSection() {
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
-          style={{
-            fontFamily: "var(--font-display)",
-            fontSize: "var(--text-xs)",
-            color: "var(--gold)",
-            fontWeight: 700,
-            letterSpacing: "0.15em",
-            textTransform: "uppercase",
-            display: "block",
-            marginBottom: "var(--sp-3)",
-          }}
+          className="block mb-3 text-xs font-bold tracking-[0.15em] uppercase"
+          style={{ color: "var(--gold)" }}
         >
-          Summoner's Rift · 5v5 Casual
+          Summoner&apos;s Rift · 5v5 Casual
         </motion.span>
 
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.55, delay: 0.08, ease: [0.16, 1, 0.3, 1] }}
+          className="font-display font-extrabold leading-[1.1] mb-4"
           style={{
             fontFamily: "var(--font-display)",
             fontSize: "clamp(2rem, 1.2rem + 2.5vw, 3.5rem)",
             color: "var(--text)",
-            fontWeight: 800,
-            lineHeight: 1.1,
-            marginBottom: "var(--sp-4)",
           }}
         >
           Torneios de<br />
@@ -60,12 +55,8 @@ export function HeroSection() {
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.16, ease: [0.16, 1, 0.3, 1] }}
-          style={{
-            fontSize: "var(--text-base)",
-            color: "var(--text-muted)",
-            marginBottom: "var(--sp-8)",
-            maxWidth: "48ch",
-          }}
+          className="mb-8"
+          style={{ fontSize: "var(--text-base)", color: "var(--text-muted)", maxWidth: "48ch" }}
         >
           Cadastre seu invocador, monte seu time e dispute torneios com bracket, stats reais e ranking oficial Riot.
         </motion.p>

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -1,0 +1,89 @@
+"use client";
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+export function HeroSection() {
+  return (
+    <section className="relative rounded-2xl overflow-hidden min-h-[400px] flex items-center">
+      {/* Fundo: imagem do Rift */}
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{
+          backgroundImage:
+            "url('https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/loadingscreen/summoners-rift.jpg')",
+          opacity: 0.28,
+        }}
+      />
+      {/* Gradiente overlay */}
+      <div className="absolute inset-0 bg-gradient-to-r from-[#050D1A] via-[#050D1A]/90 to-transparent z-10" />
+      {/* Vinheta lateral */}
+      <div className="absolute inset-0 bg-gradient-to-t from-[#050D1A]/60 to-transparent z-10" />
+
+      {/* Conteúdo */}
+      <div className="relative z-20 p-8 md:p-16 max-w-2xl">
+        <motion.span
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "var(--text-xs)",
+            color: "var(--gold)",
+            fontWeight: 700,
+            letterSpacing: "0.15em",
+            textTransform: "uppercase",
+            display: "block",
+            marginBottom: "var(--sp-3)",
+          }}
+        >
+          Summoner's Rift · 5v5 Casual
+        </motion.span>
+
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.55, delay: 0.08, ease: [0.16, 1, 0.3, 1] }}
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "clamp(2rem, 1.2rem + 2.5vw, 3.5rem)",
+            color: "var(--text)",
+            fontWeight: 800,
+            lineHeight: 1.1,
+            marginBottom: "var(--sp-4)",
+          }}
+        >
+          Torneios de<br />
+          <span style={{ color: "var(--gold)" }}>League of Legends</span>
+        </motion.h1>
+
+        <motion.p
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.16, ease: [0.16, 1, 0.3, 1] }}
+          style={{
+            fontSize: "var(--text-base)",
+            color: "var(--text-muted)",
+            marginBottom: "var(--sp-8)",
+            maxWidth: "48ch",
+          }}
+        >
+          Cadastre seu invocador, monte seu time e dispute torneios com bracket, stats reais e ranking oficial Riot.
+        </motion.p>
+
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.24, ease: [0.16, 1, 0.3, 1] }}
+          className="flex gap-4 flex-wrap"
+        >
+          <Link href="/torneios" className="btn-gold text-base px-8 py-3">
+            Ver Torneios
+          </Link>
+          <Link href="/dashboard/jogador/registrar" className="btn-outline-gold text-base px-8 py-3">
+            Cadastrar Invocador
+          </Link>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -1,7 +1,16 @@
 "use client";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { Meteors } from "@/components/ui/meteors";
+import { BackgroundBeams } from "@/components/ui/background-beams";
+import { MagneticButton } from "@/components/ui/magnetic-button";
+
+/* ─────────────────────────────────────────────────────────────────────────
+   HeroSection — PR6
+   Mudanças em relação à versão anterior:
+   • Meteors substituídos por BackgroundBeams (dourado, já customizado)
+   • CTAs envolvidos por MagneticButton
+   • Beams ficam z-0, abaixo de todos os outros layers
+───────────────────────────────────────────────────────────────────────── */
 
 export function HeroSection() {
   return (
@@ -15,16 +24,15 @@ export function HeroSection() {
           opacity: 0.28,
         }}
       />
-      {/* Gradientes */}
+
+      {/* Background Beams — z-0, atrás de tudo */}
+      <BackgroundBeams className="z-0" />
+
+      {/* Gradientes — z-10 */}
       <div className="absolute inset-0 bg-gradient-to-r from-[#050D1A] via-[#050D1A]/90 to-transparent z-10" />
       <div className="absolute inset-0 bg-gradient-to-t from-[#050D1A]/60 to-transparent z-10" />
 
-      {/* Meteoros — efeito de partículas douradas */}
-      <div className="absolute inset-0 z-10 overflow-hidden pointer-events-none">
-        <Meteors number={12} />
-      </div>
-
-      {/* Conteúdo */}
+      {/* Conteúdo — z-20 */}
       <div className="relative z-20 p-8 md:p-16 max-w-2xl">
         <motion.span
           initial={{ opacity: 0, y: 12 }}
@@ -40,7 +48,7 @@ export function HeroSection() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.55, delay: 0.08, ease: [0.16, 1, 0.3, 1] }}
-          className="font-display font-extrabold leading-[1.1] mb-4"
+          className="font-extrabold leading-[1.1] mb-4"
           style={{
             fontFamily: "var(--font-display)",
             fontSize: "clamp(2rem, 1.2rem + 2.5vw, 3.5rem)",
@@ -56,9 +64,14 @@ export function HeroSection() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.16, ease: [0.16, 1, 0.3, 1] }}
           className="mb-8"
-          style={{ fontSize: "var(--text-base)", color: "var(--text-muted)", maxWidth: "48ch" }}
+          style={{
+            fontSize: "var(--text-base)",
+            color: "var(--text-muted)",
+            maxWidth: "48ch",
+          }}
         >
-          Cadastre seu invocador, monte seu time e dispute torneios com bracket, stats reais e ranking oficial Riot.
+          Cadastre seu invocador, monte seu time e dispute torneios com
+          bracket, stats reais e ranking oficial Riot.
         </motion.p>
 
         <motion.div
@@ -67,12 +80,22 @@ export function HeroSection() {
           transition={{ duration: 0.4, delay: 0.24, ease: [0.16, 1, 0.3, 1] }}
           className="flex gap-4 flex-wrap"
         >
-          <Link href="/torneios" className="btn-gold text-base px-8 py-3">
-            Ver Torneios
-          </Link>
-          <Link href="/dashboard/jogador/registrar" className="btn-outline-gold text-base px-8 py-3">
-            Cadastrar Invocador
-          </Link>
+          {/* CTA primário — Magnetic com strength padrão */}
+          <MagneticButton strength={0.35}>
+            <Link href="/torneios" className="btn-gold text-base px-8 py-3">
+              Ver Torneios
+            </Link>
+          </MagneticButton>
+
+          {/* CTA secundário — Magnetic mais suave */}
+          <MagneticButton strength={0.22}>
+            <Link
+              href="/dashboard/jogador/registrar"
+              className="btn-outline-gold text-base px-8 py-3"
+            >
+              Cadastrar Invocador
+            </Link>
+          </MagneticButton>
         </motion.div>
       </div>
     </section>

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -3,43 +3,63 @@ import { motion } from "framer-motion";
 import { UserPlus, Shield, ClipboardList, Swords } from "lucide-react";
 import { CardSpotlight } from "@/components/ui/card-spotlight";
 
+// ---------------------------------------------------------------------------
+// Dados dos steps
+// ---------------------------------------------------------------------------
 const steps = [
   {
     step: "01",
     title: "Cadastre-se",
-    desc: "Crie sua conta e vincule seu Riot ID para importar stats reais diretamente da API da Riot Games.",
+    desc: "Crie sua conta e vincule seu Riot ID para importar stats reais diretamente da API da Riot Games. Rank, histórico de partidas e maestria de campeões sincronizados automaticamente.",
     icon: UserPlus,
-    wide: true,
+    // Layout Bento: tall card à esquerda, 2 colunas de largura e 2 linhas de altura
+    colSpan: "md:col-span-2",
+    rowSpan: "md:row-span-2",
+    horizontal: false,
+    spotlightRadius: 450,
   },
   {
     step: "02",
     title: "Monte seu Time",
     desc: "Crie um time 5v5 e convide seus amigos com convite por link.",
     icon: Shield,
-    wide: false,
+    colSpan: "md:col-span-1",
+    rowSpan: "",
+    horizontal: false,
+    spotlightRadius: 350,
   },
   {
     step: "03",
     title: "Inscreva-se",
-    desc: "Encontre um torneio aberto e inscreva seu time.",
+    desc: "Encontre um torneio aberto e inscreva seu time em segundos.",
     icon: ClipboardList,
-    wide: false,
+    colSpan: "md:col-span-1",
+    rowSpan: "",
+    horizontal: false,
+    spotlightRadius: 350,
   },
   {
     step: "04",
-    title: "Dispute",
-    desc: "Jogue, reporte resultados e acompanhe o bracket ao vivo.",
+    title: "Dispute & Acompanhe",
+    desc: "Jogue as partidas via Tournament Code, reporte resultados e assista o bracket ao vivo atualizar em tempo real.",
     icon: Swords,
-    wide: false,
+    // Full-width na linha de baixo, layout horizontal
+    colSpan: "md:col-span-3",
+    rowSpan: "",
+    horizontal: true,
+    spotlightRadius: 500,
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Animações
+// ---------------------------------------------------------------------------
 const container = {
   hidden: {},
-  show: { transition: { staggerChildren: 0.1 } },
+  show: { transition: { staggerChildren: 0.09 } },
 };
 
-const item = {
+const itemVariant = {
   hidden: { opacity: 0, y: 28 },
   show: {
     opacity: 1,
@@ -48,44 +68,92 @@ const item = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// Componente
+// ---------------------------------------------------------------------------
 export function HowItWorks() {
   return (
     <section>
-      <motion.h2
+      {/* Título da seção */}
+      <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
-        style={{
-          fontFamily: "var(--font-display)",
-          fontSize: "var(--text-xl)",
-          color: "var(--text)",
-          marginBottom: "var(--sp-8)",
-        }}
+        style={{ marginBottom: "var(--sp-8)" }}
       >
-        Como funciona
-      </motion.h2>
+        <p
+          style={{
+            fontSize: "var(--text-xs)",
+            fontWeight: 700,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: "var(--gold)",
+            marginBottom: "var(--sp-2)",
+          }}
+        >
+          Passo a passo
+        </p>
+        <h2
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "var(--text-xl)",
+            color: "var(--text)",
+            fontWeight: 700,
+          }}
+        >
+          Como funciona
+        </h2>
+      </motion.div>
 
+      {/* Grid Bento */}
       <motion.div
         variants={container}
         initial="hidden"
         whileInView="show"
         viewport={{ once: true, margin: "-60px" }}
-        className="grid grid-cols-1 md:grid-cols-3 gap-5"
+        className="grid grid-cols-1 md:grid-cols-3 md:grid-rows-[auto_auto_auto] gap-4"
       >
-        {steps.map((s, idx) => {
+        {steps.map((s) => {
           const Icon = s.icon;
           return (
             <motion.div
               key={s.step}
-              variants={item}
-              className={idx === 0 ? "md:col-span-3" : ""}
+              variants={itemVariant}
+              className={[s.colSpan, s.rowSpan].filter(Boolean).join(" ")}
+              style={{ minHeight: s.rowSpan ? 260 : undefined }}
             >
               <CardSpotlight
-                className={`h-full flex flex-col gap-4${
-                  idx === 0 ? " md:flex-row md:items-center md:gap-8" : ""
-                }`}
+                radius={s.spotlightRadius}
+                className={[
+                  "h-full relative",
+                  s.horizontal
+                    ? "flex flex-col md:flex-row md:items-center gap-6"
+                    : "flex flex-col gap-4",
+                ].join(" ")}
               >
+                {/* Background label — número do step como watermark */}
+                <span
+                  aria-hidden="true"
+                  style={{
+                    position: "absolute",
+                    right: "-0.05em",
+                    bottom: "-0.25em",
+                    fontFamily: "var(--font-display)",
+                    fontSize: "clamp(4rem, 10vw, 8rem)",
+                    fontWeight: 900,
+                    color: "var(--text-faint)",
+                    opacity: 0.18,
+                    lineHeight: 1,
+                    userSelect: "none",
+                    pointerEvents: "none",
+                    letterSpacing: "-0.04em",
+                  }}
+                >
+                  {s.step}
+                </span>
+
+                {/* Ícone */}
                 <div
                   style={{
                     width: 52,
@@ -98,11 +166,16 @@ export function HowItWorks() {
                     alignItems: "center",
                     justifyContent: "center",
                     color: "var(--gold)",
+                    flexShrink: 0,
+                    position: "relative",
+                    zIndex: 1,
                   }}
                 >
                   <Icon size={24} />
                 </div>
-                <div>
+
+                {/* Conteúdo */}
+                <div style={{ position: "relative", zIndex: 1, flex: 1 }}>
                   <span
                     style={{
                       fontFamily: "var(--font-display)",
@@ -128,9 +201,48 @@ export function HowItWorks() {
                   >
                     {s.title}
                   </h3>
-                  <p style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", maxWidth: "42ch" }}>
+                  <p
+                    style={{
+                      fontSize: "var(--text-sm)",
+                      color: "var(--text-muted)",
+                      maxWidth: s.horizontal ? "60ch" : "34ch",
+                      lineHeight: 1.65,
+                    }}
+                  >
                     {s.desc}
                   </p>
+
+                  {/* Conector visual — apenas no card 01 (tall) */}
+                  {s.step === "01" && (
+                    <div
+                      aria-hidden="true"
+                      style={{
+                        marginTop: "var(--sp-6)",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "var(--sp-2)",
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 1,
+                          height: 40,
+                          borderLeft: "1px dashed var(--border)",
+                          opacity: 0.5,
+                          marginLeft: 1,
+                        }}
+                      />
+                      <span
+                        style={{
+                          fontSize: "var(--text-xs)",
+                          color: "var(--text-faint)",
+                          letterSpacing: "0.06em",
+                        }}
+                      >
+                        continue abaixo
+                      </span>
+                    </div>
+                  )}
                 </div>
               </CardSpotlight>
             </motion.div>

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { motion } from "framer-motion";
 import { UserPlus, Shield, ClipboardList, Swords } from "lucide-react";
+import { CardSpotlight } from "@/components/ui/card-spotlight";
 
 const steps = [
   {
     step: "01",
     title: "Cadastre-se",
-    desc: "Crie sua conta e vincule seu Riot ID para importar stats reais.",
+    desc: "Crie sua conta e vincule seu Riot ID para importar stats reais diretamente da API da Riot Games.",
     icon: UserPlus,
     wide: true,
   },
@@ -78,57 +79,60 @@ export function HowItWorks() {
             <motion.div
               key={s.step}
               variants={item}
-              whileHover={{ y: -4, transition: { duration: 0.2 } }}
-              className={`card flex flex-col gap-4${
-                idx === 0 ? " md:col-span-3 md:flex-row md:items-center md:gap-8" : ""
-              }`}
+              className={idx === 0 ? "md:col-span-3" : ""}
             >
-              <div
-                style={{
-                  width: 52,
-                  height: 52,
-                  minWidth: 52,
-                  borderRadius: "var(--radius-lg)",
-                  background: "var(--gold-dim)",
-                  border: "1px solid var(--border-gold)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  color: "var(--gold)",
-                }}
+              <CardSpotlight
+                className={`h-full flex flex-col gap-4${
+                  idx === 0 ? " md:flex-row md:items-center md:gap-8" : ""
+                }`}
               >
-                <Icon size={24} />
-              </div>
-              <div>
-                <span
+                <div
                   style={{
-                    fontFamily: "var(--font-display)",
-                    fontSize: "var(--text-xs)",
+                    width: 52,
+                    height: 52,
+                    minWidth: 52,
+                    borderRadius: "var(--radius-lg)",
+                    background: "var(--gold-dim)",
+                    border: "1px solid var(--border-gold)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
                     color: "var(--gold)",
-                    fontWeight: 700,
-                    letterSpacing: "0.1em",
-                    textTransform: "uppercase",
-                    display: "block",
-                    marginBottom: "var(--sp-1)",
                   }}
                 >
-                  PASSO {s.step}
-                </span>
-                <h3
-                  style={{
-                    fontFamily: "var(--font-display)",
-                    fontSize: "var(--text-lg)",
-                    color: "var(--text)",
-                    fontWeight: 700,
-                    marginBottom: "var(--sp-2)",
-                  }}
-                >
-                  {s.title}
-                </h3>
-                <p style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", maxWidth: "42ch" }}>
-                  {s.desc}
-                </p>
-              </div>
+                  <Icon size={24} />
+                </div>
+                <div>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-display)",
+                      fontSize: "var(--text-xs)",
+                      color: "var(--gold)",
+                      fontWeight: 700,
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      display: "block",
+                      marginBottom: "var(--sp-1)",
+                    }}
+                  >
+                    PASSO {s.step}
+                  </span>
+                  <h3
+                    style={{
+                      fontFamily: "var(--font-display)",
+                      fontSize: "var(--text-lg)",
+                      color: "var(--text)",
+                      fontWeight: 700,
+                      marginBottom: "var(--sp-2)",
+                    }}
+                  >
+                    {s.title}
+                  </h3>
+                  <p style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", maxWidth: "42ch" }}>
+                    {s.desc}
+                  </p>
+                </div>
+              </CardSpotlight>
             </motion.div>
           );
         })}

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -1,0 +1,138 @@
+"use client";
+import { motion } from "framer-motion";
+import { UserPlus, Shield, ClipboardList, Swords } from "lucide-react";
+
+const steps = [
+  {
+    step: "01",
+    title: "Cadastre-se",
+    desc: "Crie sua conta e vincule seu Riot ID para importar stats reais.",
+    icon: UserPlus,
+    wide: true,
+  },
+  {
+    step: "02",
+    title: "Monte seu Time",
+    desc: "Crie um time 5v5 e convide seus amigos com convite por link.",
+    icon: Shield,
+    wide: false,
+  },
+  {
+    step: "03",
+    title: "Inscreva-se",
+    desc: "Encontre um torneio aberto e inscreva seu time.",
+    icon: ClipboardList,
+    wide: false,
+  },
+  {
+    step: "04",
+    title: "Dispute",
+    desc: "Jogue, reporte resultados e acompanhe o bracket ao vivo.",
+    icon: Swords,
+    wide: false,
+  },
+];
+
+const container = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.1 } },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 28 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: [0.16, 1, 0.3, 1] },
+  },
+};
+
+export function HowItWorks() {
+  return (
+    <section>
+      <motion.h2
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "var(--text-xl)",
+          color: "var(--text)",
+          marginBottom: "var(--sp-8)",
+        }}
+      >
+        Como funciona
+      </motion.h2>
+
+      <motion.div
+        variants={container}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, margin: "-60px" }}
+        className="grid grid-cols-1 md:grid-cols-3 gap-5"
+      >
+        {steps.map((s, idx) => {
+          const Icon = s.icon;
+          return (
+            <motion.div
+              key={s.step}
+              variants={item}
+              whileHover={{ y: -4, transition: { duration: 0.2 } }}
+              className={`card flex flex-col gap-4${
+                idx === 0 ? " md:col-span-3 md:flex-row md:items-center md:gap-8" : ""
+              }`}
+            >
+              <div
+                style={{
+                  width: 52,
+                  height: 52,
+                  minWidth: 52,
+                  borderRadius: "var(--radius-lg)",
+                  background: "var(--gold-dim)",
+                  border: "1px solid var(--border-gold)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "var(--gold)",
+                }}
+              >
+                <Icon size={24} />
+              </div>
+              <div>
+                <span
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontSize: "var(--text-xs)",
+                    color: "var(--gold)",
+                    fontWeight: 700,
+                    letterSpacing: "0.1em",
+                    textTransform: "uppercase",
+                    display: "block",
+                    marginBottom: "var(--sp-1)",
+                  }}
+                >
+                  PASSO {s.step}
+                </span>
+                <h3
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontSize: "var(--text-lg)",
+                    color: "var(--text)",
+                    fontWeight: 700,
+                    marginBottom: "var(--sp-2)",
+                  }}
+                >
+                  {s.title}
+                </h3>
+                <p style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", maxWidth: "42ch" }}>
+                  {s.desc}
+                </p>
+              </div>
+            </motion.div>
+          );
+        })}
+      </motion.div>
+    </section>
+  );
+}

--- a/components/home/StatsSection.tsx
+++ b/components/home/StatsSection.tsx
@@ -1,12 +1,8 @@
 "use client";
 import { motion } from "framer-motion";
 import { Users, Shield, Trophy, Map } from "lucide-react";
-
-interface Stat {
-  label: string;
-  value: number | string;
-  icon: React.ReactNode;
-}
+import { ShootingStars } from "@/components/ui/shooting-stars";
+import { FlipBoard } from "@/components/ui/text-flip-board";
 
 interface StatsSectionProps {
   totalPlayers: number;
@@ -16,80 +12,130 @@ interface StatsSectionProps {
 
 const container = {
   hidden: {},
-  show: { transition: { staggerChildren: 0.08 } },
+  show: { transition: { staggerChildren: 0.1 } },
 };
 
 const item = {
-  hidden: { opacity: 0, y: 24 },
+  hidden: { opacity: 0, y: 28 },
   show: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.45, ease: [0.16, 1, 0.3, 1] },
+    transition: { duration: 0.5, ease: [0.16, 1, 0.3, 1] },
   },
 };
+
+interface StatItem {
+  label: string;
+  value: number | string;
+  icon: React.ReactNode;
+  numeric: boolean;
+}
 
 export function StatsSection({
   totalPlayers,
   totalTeams,
   totalTournaments,
 }: StatsSectionProps) {
-  const stats: Stat[] = [
-    { label: "Invocadores", value: totalPlayers,    icon: <Users   size={22} /> },
-    { label: "Times",       value: totalTeams,      icon: <Shield  size={22} /> },
-    { label: "Torneios",    value: totalTournaments, icon: <Trophy  size={22} /> },
-    { label: "Mapa",        value: "SR 5v5",        icon: <Map     size={22} /> },
+  const stats: StatItem[] = [
+    { label: "Invocadores", value: totalPlayers,     icon: <Users  size={22} />, numeric: true  },
+    { label: "Times",       value: totalTeams,       icon: <Shield size={22} />, numeric: true  },
+    { label: "Torneios",    value: totalTournaments, icon: <Trophy size={22} />, numeric: true  },
+    { label: "Mapa",        value: "SR 5v5",         icon: <Map    size={22} />, numeric: false },
   ];
 
   return (
-    <motion.section
-      variants={container}
-      initial="hidden"
-      whileInView="show"
-      viewport={{ once: true, margin: "-60px" }}
-      className="grid grid-cols-2 md:grid-cols-4 gap-4"
+    <section
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        borderRadius: "var(--radius-xl)",
+        padding: "var(--sp-8) var(--sp-4)",
+        background: "linear-gradient(135deg, rgba(200,168,75,0.04) 0%, transparent 60%)",
+        border: "1px solid var(--border)",
+      }}
     >
-      {stats.map((s) => (
-        <motion.div
-          key={s.label}
-          variants={item}
-          className="card text-center py-6 cursor-default"
-          whileHover={{ y: -4, transition: { duration: 0.2 } }}
-        >
-          <div
-            className="mx-auto mb-3 flex items-center justify-center"
-            style={{
-              width: 44,
-              height: 44,
-              borderRadius: "var(--radius-md)",
-              background: "var(--gold-dim)",
-              border: "1px solid var(--border-gold)",
-              color: "var(--gold)",
-            }}
+      {/* Shooting stars de fundo */}
+      <ShootingStars
+        minSpeed={6}
+        maxSpeed={18}
+        minDelay={1200}
+        maxDelay={4000}
+        starColor="#C8A84B"
+        trailColor="rgba(200,168,75,0.10)"
+        starWidth={1.5}
+        starHeight={1}
+      />
+
+      <motion.div
+        variants={container}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, margin: "-60px" }}
+        className="grid grid-cols-2 md:grid-cols-4 gap-4"
+        style={{ position: "relative", zIndex: 1 }}
+      >
+        {stats.map((s) => (
+          <motion.div
+            key={s.label}
+            variants={item}
+            className="card text-center py-6 cursor-default"
+            whileHover={{ y: -4, transition: { duration: 0.2 } }}
+            style={{ background: "rgba(10,20,40,0.7)", backdropFilter: "blur(8px)" }}
           >
-            {s.icon}
-          </div>
-          <p
-            className="font-bold tabular-nums"
-            style={{
-              fontFamily: "var(--font-display)",
-              fontSize: "var(--text-xl)",
-              color: "var(--gold)",
-              lineHeight: 1.1,
-            }}
-          >
-            {s.value}
-          </p>
-          <p
-            style={{
-              fontSize: "var(--text-sm)",
-              color: "var(--text-muted)",
-              marginTop: "var(--sp-1)",
-            }}
-          >
-            {s.label}
-          </p>
-        </motion.div>
-      ))}
-    </motion.section>
+            {/* Ícone */}
+            <div
+              className="mx-auto mb-3 flex items-center justify-center"
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: "var(--radius-md)",
+                background: "var(--gold-dim)",
+                border: "1px solid var(--border-gold)",
+                color: "var(--gold)",
+              }}
+            >
+              {s.icon}
+            </div>
+
+            {/* Valor — numérico usa FlipBoard, texto usa span normal */}
+            <div
+              className="font-bold tabular-nums"
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: "var(--text-xl)",
+                color: "var(--gold)",
+                lineHeight: 1.1,
+                minHeight: "1.4em",
+              }}
+            >
+              {s.numeric ? (
+                <FlipBoard
+                  value={s.value as number}
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontSize: "var(--text-xl)",
+                    fontWeight: 700,
+                    color: "var(--gold)",
+                    lineHeight: 1.1,
+                  }}
+                />
+              ) : (
+                <span>{s.value}</span>
+              )}
+            </div>
+
+            <p
+              style={{
+                fontSize: "var(--text-sm)",
+                color: "var(--text-muted)",
+                marginTop: "var(--sp-1)",
+              }}
+            >
+              {s.label}
+            </p>
+          </motion.div>
+        ))}
+      </motion.div>
+    </section>
   );
 }

--- a/components/home/StatsSection.tsx
+++ b/components/home/StatsSection.tsx
@@ -1,0 +1,95 @@
+"use client";
+import { motion } from "framer-motion";
+import { Users, Shield, Trophy, Map } from "lucide-react";
+
+interface Stat {
+  label: string;
+  value: number | string;
+  icon: React.ReactNode;
+}
+
+interface StatsSectionProps {
+  totalPlayers: number;
+  totalTeams: number;
+  totalTournaments: number;
+}
+
+const container = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.08 } },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 24 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.45, ease: [0.16, 1, 0.3, 1] },
+  },
+};
+
+export function StatsSection({
+  totalPlayers,
+  totalTeams,
+  totalTournaments,
+}: StatsSectionProps) {
+  const stats: Stat[] = [
+    { label: "Invocadores", value: totalPlayers,    icon: <Users   size={22} /> },
+    { label: "Times",       value: totalTeams,      icon: <Shield  size={22} /> },
+    { label: "Torneios",    value: totalTournaments, icon: <Trophy  size={22} /> },
+    { label: "Mapa",        value: "SR 5v5",        icon: <Map     size={22} /> },
+  ];
+
+  return (
+    <motion.section
+      variants={container}
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once: true, margin: "-60px" }}
+      className="grid grid-cols-2 md:grid-cols-4 gap-4"
+    >
+      {stats.map((s) => (
+        <motion.div
+          key={s.label}
+          variants={item}
+          className="card text-center py-6 cursor-default"
+          whileHover={{ y: -4, transition: { duration: 0.2 } }}
+        >
+          <div
+            className="mx-auto mb-3 flex items-center justify-center"
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: "var(--radius-md)",
+              background: "var(--gold-dim)",
+              border: "1px solid var(--border-gold)",
+              color: "var(--gold)",
+            }}
+          >
+            {s.icon}
+          </div>
+          <p
+            className="font-bold tabular-nums"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: "var(--text-xl)",
+              color: "var(--gold)",
+              lineHeight: 1.1,
+            }}
+          >
+            {s.value}
+          </p>
+          <p
+            style={{
+              fontSize: "var(--text-sm)",
+              color: "var(--text-muted)",
+              marginTop: "var(--sp-1)",
+            }}
+          >
+            {s.label}
+          </p>
+        </motion.div>
+      ))}
+    </motion.section>
+  );
+}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -2,22 +2,22 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { NotificationBell } from "@/components/layout/NotificationBell";
+import { Swords } from "lucide-react";
 
 type Me = { id: string; email: string } | null;
 
 export function Navbar() {
-  const [user, setUser]       = useState<Me>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [user, setUser]         = useState<Me>(null);
+  const [isAdmin, setIsAdmin]   = useState(false);
+  const [loading, setLoading]   = useState(true);
   const [loggingOut, setLoggingOut] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const pathname = usePathname();
 
-  // Fecha menu mobile ao trocar de rota
   useEffect(() => { setMenuOpen(false); }, [pathname]);
 
-  // Busca estado de autenticacao via server-side (bypassa RLS para is_admin)
   async function fetchMe() {
     try {
       const res = await fetch('/api/auth/me', { cache: 'no-store' });
@@ -33,39 +33,52 @@ export function Navbar() {
     }
   }
 
-  useEffect(() => {
-    fetchMe();
-  }, [pathname]); // Re-verifica ao mudar de pagina
+  useEffect(() => { fetchMe(); }, [pathname]);
 
   async function handleLogout() {
     if (loggingOut) return;
     setLoggingOut(true);
-    try {
-      await fetch('/api/auth/signout', { method: 'POST' });
-    } catch {
-      // ignora erro de rede, continua o redirect
-    }
-    // Recarga completa — cookies ja foram limpos server-side
+    try { await fetch('/api/auth/signout', { method: 'POST' }); } catch {}
     window.location.href = '/';
   }
 
   const NAV_LINKS = [
-    { href: '/torneios',  label: 'Torneios' },
-    { href: '/times',     label: 'Times'    },
-    { href: '/jogadores', label: 'Jogadores'},
-    { href: '/ranking',   label: 'Ranking'  },
+    { href: '/torneios',  label: 'Torneios'  },
+    { href: '/times',     label: 'Times'     },
+    { href: '/jogadores', label: 'Jogadores' },
+    { href: '/ranking',   label: 'Ranking'   },
   ];
 
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(href + '/');
 
   return (
-    <nav className="bg-[#050E1A] border-b border-[#1E3A5F] px-4 py-3">
-      <div className="max-w-7xl mx-auto flex items-center justify-between">
+    <nav
+      style={{
+        background: "rgba(5,13,26,0.95)",
+        borderBottom: "1px solid var(--border)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        position: "sticky",
+        top: 0,
+        zIndex: 50,
+      }}
+    >
+      <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
         {/* Logo */}
-        <Link href="/" className="flex items-center gap-2 font-bold text-white shrink-0">
-          <span>⚔️</span>
-          <span className="hidden sm:inline">LoL Tournament</span>
+        <Link
+          href="/"
+          className="flex items-center gap-2 shrink-0"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontWeight: 800,
+            fontSize: "var(--text-base)",
+            color: "var(--text)",
+            textDecoration: "none",
+          }}
+        >
+          <Swords size={20} style={{ color: "var(--gold)" }} />
+          <span className="hidden sm:inline">ArenaGG</span>
         </Link>
 
         {/* Links desktop */}
@@ -74,25 +87,33 @@ export function Navbar() {
             <Link
               key={href}
               href={href}
-              className={`px-3 py-1.5 rounded text-sm transition-colors ${
-                isActive(href)
-                  ? 'text-[#C8A84B] bg-[#C8A84B]/10 font-medium'
-                  : 'text-gray-400 hover:text-white hover:bg-white/5'
-              }`}
+              style={{
+                padding: "6px 12px",
+                borderRadius: "var(--radius-sm)",
+                fontSize: "var(--text-sm)",
+                fontWeight: isActive(href) ? 600 : 400,
+                color: isActive(href) ? "var(--gold)" : "var(--text-muted)",
+                background: isActive(href) ? "var(--gold-dim)" : "transparent",
+                transition: "color var(--duration), background var(--duration)",
+                textDecoration: "none",
+              }}
             >
               {label}
             </Link>
           ))}
-
-          {/* Link Admin — so aparece se isAdmin=true */}
           {!loading && isAdmin && (
             <Link
               href="/admin"
-              className={`px-3 py-1.5 rounded text-sm font-semibold transition-colors ${
-                pathname.startsWith('/admin')
-                  ? 'text-[#C8A84B] bg-[#C8A84B]/10'
-                  : 'text-red-400 hover:text-red-300 hover:bg-red-400/5'
-              }`}
+              style={{
+                padding: "6px 12px",
+                borderRadius: "var(--radius-sm)",
+                fontSize: "var(--text-sm)",
+                fontWeight: 600,
+                color: pathname.startsWith('/admin') ? "var(--gold)" : "#f87171",
+                background: pathname.startsWith('/admin') ? "var(--gold-dim)" : "transparent",
+                transition: "color var(--duration), background var(--duration)",
+                textDecoration: "none",
+              }}
             >
               ⚙️ Admin
             </Link>
@@ -102,24 +123,34 @@ export function Navbar() {
         {/* Auth (desktop) */}
         <div className="hidden md:flex items-center gap-2">
           {loading ? (
-            <span className="text-gray-500 text-sm animate-pulse">•••</span>
+            <span style={{ color: "var(--text-faint)", fontSize: "var(--text-sm)" }} className="animate-pulse">•••</span>
           ) : user ? (
             <>
               <NotificationBell userId={user.id} />
               <Link
                 href="/dashboard"
-                className={`text-sm px-3 py-1.5 rounded transition-colors ${
-                  pathname === '/dashboard'
-                    ? 'text-[#C8A84B]'
-                    : 'text-gray-400 hover:text-white'
-                }`}
+                style={{
+                  fontSize: "var(--text-sm)",
+                  color: pathname === '/dashboard' ? "var(--gold)" : "var(--text-muted)",
+                  padding: "6px 12px",
+                  borderRadius: "var(--radius-sm)",
+                  textDecoration: "none",
+                  transition: "color var(--duration)",
+                }}
               >
                 Dashboard
               </Link>
               <button
                 onClick={handleLogout}
                 disabled={loggingOut}
-                className="text-sm text-gray-400 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed px-3 py-1.5 rounded transition-colors"
+                style={{
+                  fontSize: "var(--text-sm)",
+                  color: "var(--text-muted)",
+                  padding: "6px 12px",
+                  borderRadius: "var(--radius-sm)",
+                  transition: "color var(--duration)",
+                }}
+                className="hover:text-red-400 disabled:opacity-50"
               >
                 {loggingOut ? 'Saindo...' : 'Sair'}
               </button>
@@ -128,86 +159,134 @@ export function Navbar() {
             <>
               <Link
                 href="/login"
-                className="text-sm text-gray-400 hover:text-white px-3 py-1.5 rounded transition-colors"
+                style={{
+                  fontSize: "var(--text-sm)",
+                  color: "var(--text-muted)",
+                  padding: "6px 12px",
+                  borderRadius: "var(--radius-sm)",
+                  textDecoration: "none",
+                  transition: "color var(--duration)",
+                }}
+                className="hover:text-white"
               >
                 Entrar
               </Link>
-              <Link
-                href="/register"
-                className="text-sm bg-[#C8A84B] hover:bg-[#d4b55a] text-black font-semibold px-3 py-1.5 rounded transition-colors"
-              >
+              <Link href="/register" className="btn-gold" style={{ padding: "6px 16px", fontSize: "var(--text-sm)" }}>
                 Cadastrar
               </Link>
             </>
           )}
         </div>
 
-        {/* Botão hambúrguer (mobile) */}
+        {/* Hambúrguer mobile */}
         <button
-          className="md:hidden text-gray-400 hover:text-white p-1.5 rounded transition-colors"
-          onClick={() => setMenuOpen(v => !v)}
+          className="md:hidden p-2 rounded"
+          style={{ color: "var(--text-muted)", transition: "color var(--duration)" }}
+          onClick={() => setMenuOpen((v) => !v)}
           aria-label={menuOpen ? 'Fechar menu' : 'Abrir menu'}
         >
-          {menuOpen ? (
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M18 6L6 18M6 6l12 12"/>
-            </svg>
-          ) : (
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M3 12h18M3 6h18M3 18h18"/>
-            </svg>
-          )}
+          <motion.svg
+            width="22" height="22" viewBox="0 0 24 24"
+            fill="none" stroke="currentColor" strokeWidth="2"
+            animate={menuOpen ? "open" : "closed"}
+          >
+            <motion.path
+              variants={{
+                closed: { d: "M3 6h18" },
+                open:   { d: "M6 18L18 6" },
+              }}
+              transition={{ duration: 0.25 }}
+            />
+            <motion.path
+              variants={{
+                closed: { d: "M3 12h18", opacity: 1 },
+                open:   { d: "M3 12h18",  opacity: 0 },
+              }}
+              transition={{ duration: 0.15 }}
+            />
+            <motion.path
+              variants={{
+                closed: { d: "M3 18h18" },
+                open:   { d: "M6 6l12 12" },
+              }}
+              transition={{ duration: 0.25 }}
+            />
+          </motion.svg>
         </button>
       </div>
 
-      {/* Menu mobile */}
-      {menuOpen && (
-        <div className="md:hidden mt-3 border-t border-[#1E3A5F] pt-3 flex flex-col gap-1">
-          {NAV_LINKS.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className={`px-3 py-2 rounded text-sm transition-colors ${
-                isActive(href)
-                  ? 'text-[#C8A84B] bg-[#C8A84B]/10 font-medium'
-                  : 'text-gray-400 hover:text-white hover:bg-white/5'
-              }`}
-            >
-              {label}
-            </Link>
-          ))}
-          {!loading && isAdmin && (
-            <Link href="/admin" className="px-3 py-2 rounded text-sm font-semibold text-red-400 hover:text-red-300">
-              ⚙️ Admin
-            </Link>
-          )}
-          <div className="border-t border-[#1E3A5F] mt-2 pt-2 flex flex-col gap-1">
-            {loading ? null : user ? (
-              <>
-                <Link href="/dashboard" className="px-3 py-2 rounded text-sm text-gray-400 hover:text-white">
-                  Dashboard
-                </Link>
-                <button
-                  onClick={handleLogout}
-                  disabled={loggingOut}
-                  className="text-left px-3 py-2 rounded text-sm text-gray-400 hover:text-red-400 disabled:opacity-50"
+      {/* Menu mobile — AnimatePresence para slide suave */}
+      <AnimatePresence>
+        {menuOpen && (
+          <motion.div
+            key="mobile-menu"
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+            style={{ overflow: "hidden", borderTop: "1px solid var(--border)" }}
+          >
+            <div className="px-4 py-3 flex flex-col gap-1">
+              {NAV_LINKS.map(({ href, label }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  style={{
+                    padding: "10px 12px",
+                    borderRadius: "var(--radius-sm)",
+                    fontSize: "var(--text-sm)",
+                    fontWeight: isActive(href) ? 600 : 400,
+                    color: isActive(href) ? "var(--gold)" : "var(--text-muted)",
+                    background: isActive(href) ? "var(--gold-dim)" : "transparent",
+                    textDecoration: "none",
+                    display: "block",
+                  }}
                 >
-                  {loggingOut ? 'Saindo...' : 'Sair'}
-                </button>
-              </>
-            ) : (
-              <>
-                <Link href="/login" className="px-3 py-2 rounded text-sm text-gray-400 hover:text-white">
-                  Entrar
+                  {label}
                 </Link>
-                <Link href="/register" className="px-3 py-2 rounded text-sm bg-[#C8A84B] text-black font-semibold text-center">
-                  Cadastrar
+              ))}
+              {!loading && isAdmin && (
+                <Link href="/admin"
+                  style={{ padding: "10px 12px", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)", fontWeight: 600, color: "#f87171", textDecoration: "none", display: "block" }}
+                >
+                  ⚙️ Admin
                 </Link>
-              </>
-            )}
-          </div>
-        </div>
-      )}
+              )}
+              <div style={{ borderTop: "1px solid var(--border-soft)", marginTop: "var(--sp-2)", paddingTop: "var(--sp-2)", display: "flex", flexDirection: "column", gap: "var(--sp-1)" }}>
+                {loading ? null : user ? (
+                  <>
+                    <Link href="/dashboard"
+                      style={{ padding: "10px 12px", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)", color: "var(--text-muted)", textDecoration: "none", display: "block" }}
+                    >
+                      Dashboard
+                    </Link>
+                    <button
+                      onClick={handleLogout}
+                      disabled={loggingOut}
+                      style={{ textAlign: "left", padding: "10px 12px", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)", color: "var(--text-muted)", background: "none", border: "none", cursor: "pointer", opacity: loggingOut ? 0.5 : 1 }}
+                    >
+                      {loggingOut ? 'Saindo...' : 'Sair'}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <Link href="/login"
+                      style={{ padding: "10px 12px", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)", color: "var(--text-muted)", textDecoration: "none", display: "block" }}
+                    >
+                      Entrar
+                    </Link>
+                    <Link href="/register" className="btn-gold"
+                      style={{ textAlign: "center", padding: "10px 12px", fontSize: "var(--text-sm)" }}
+                    >
+                      Cadastrar
+                    </Link>
+                  </>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </nav>
   );
 }

--- a/components/profile/ChampionStatsTable.tsx
+++ b/components/profile/ChampionStatsTable.tsx
@@ -1,5 +1,11 @@
 import Image from 'next/image';
 
+// CommunityDragon por championId numérico — padrão do projeto
+// Usado aqui via championName → precisamos do ID. Como ChampionStatsTable recebe apenas `name` (string),
+// usamos o endpoint CDragon de ícone por nome (slug lowercase) que é estável:
+const CDN_CHAMPION_BY_NAME = (name: string) =>
+  `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons-by-name/${name.toLowerCase()}.png`;
+
 interface ChampStat {
   name: string;
   games: number;
@@ -8,67 +14,114 @@ interface ChampStat {
   kills: number;
   deaths: number;
   assists: number;
+  championId?: number; // opcional: se disponível, usa por ID (mais preciso)
 }
 
+// DD_VERSION removido — não mais necessário
 interface Props {
   champions: ChampStat[];
-  DD_VERSION: string;
 }
 
-export default function ChampionStatsTable({ champions, DD_VERSION }: Props) {
+export default function ChampionStatsTable({ champions }: Props) {
   if (!champions.length) {
     return (
-      <div className="bg-[#0D1421] border border-[#1E2D45] rounded-xl p-4 text-[#4A5568] text-sm text-center">
+      <div
+        className="rounded-xl p-4 text-center"
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          color: 'var(--text-faint)',
+          fontSize: 'var(--text-sm)',
+        }}
+      >
         Sem dados suficientes.
       </div>
     );
   }
 
   return (
-    <div className="bg-[#0D1421] border border-[#1E2D45] rounded-xl overflow-hidden">
-      <table className="w-full text-xs">
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+    >
+      <table className="w-full" style={{ fontSize: 'var(--text-xs)' }}>
         <thead>
-          <tr className="border-b border-[#1E2D45]">
-            <th className="text-left text-[#4A5568] font-semibold uppercase tracking-widest py-2 px-3">Campeão</th>
-            <th className="text-center text-[#4A5568] font-semibold uppercase tracking-widest py-2 px-2">Jogos</th>
-            <th className="text-center text-[#4A5568] font-semibold uppercase tracking-widest py-2 px-2">WR</th>
-            <th className="text-center text-[#4A5568] font-semibold uppercase tracking-widest py-2 px-2">KDA</th>
+          <tr style={{ borderBottom: '1px solid var(--border)' }}>
+            {['Campeão', 'Jogos', 'WR', 'KDA'].map((h, i) => (
+              <th
+                key={h}
+                className={i === 0 ? 'text-left' : 'text-center'}
+                style={{
+                  color: 'var(--text-muted)',
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                  padding: '8px 12px',
+                }}
+              >
+                {h}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
           {champions.map((c, i) => {
             const wrColor =
-              c.wr >= 60 ? 'text-[#F6AD55]' :
-              c.wr >= 50 ? 'text-[#68D391]' : 'text-[#FC8181]';
+              c.wr >= 60 ? 'var(--gold)' :
+              c.wr >= 50 ? 'var(--win)' : 'var(--loss)';
             const kdaNum = parseFloat(c.kda);
             const kdaColor =
-              c.kda === 'Perfect' || kdaNum >= 5 ? 'text-[#F0C040]' :
-              kdaNum >= 3 ? 'text-[#68D391]' :
-              kdaNum >= 2 ? 'text-[#A0AEC0]' : 'text-[#FC8181]';
+              c.kda === 'Perfect' || kdaNum >= 5 ? 'var(--gold)' :
+              kdaNum >= 3 ? 'var(--win)' :
+              kdaNum >= 2 ? 'var(--text-muted)' : 'var(--loss)';
+
+            // Usa CDragon por ID se disponível, senão por nome (slug)
+            const iconSrc = c.championId
+              ? `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/${c.championId}.png`
+              : CDN_CHAMPION_BY_NAME(c.name);
+
             return (
               <tr
                 key={c.name}
-                className={`border-b border-[#1A2535] hover:bg-[#111B2E] transition-colors ${
-                  i === champions.length - 1 ? 'border-b-0' : ''
-                }`}
+                style={{
+                  borderBottom: i === champions.length - 1 ? 'none' : '1px solid var(--border-soft)',
+                  transition: 'background 150ms ease',
+                }}
+                className="hover:bg-[var(--surface-2)]"
               >
-                <td className="py-2.5 px-3">
+                <td style={{ padding: '10px 12px' }}>
                   <div className="flex items-center gap-2">
                     <Image
-                      src={`https://ddragon.leagueoflegends.com/cdn/${DD_VERSION}/img/champion/${c.name}.png`}
+                      src={iconSrc}
                       width={28}
                       height={28}
                       alt={c.name}
-                      className="rounded border border-[#1E3A5F]"
+                      loading="lazy"
+                      className="rounded"
+                      style={{ border: '1px solid var(--border)' }}
+                      onError={(e) => {
+                        // fallback para ícone genérico CDragon se slug não bater
+                        (e.currentTarget as HTMLImageElement).src =
+                          'https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/-1.png';
+                      }}
                     />
-                    <span className="text-[#E2E8F0] font-medium truncate max-w-[80px]">{c.name}</span>
+                    <span
+                      className="truncate max-w-[80px]"
+                      style={{ color: 'var(--text)', fontWeight: 500 }}
+                    >
+                      {c.name}
+                    </span>
                   </div>
                 </td>
-                <td className="text-center text-[#A0AEC0] py-2.5 px-2">{c.games}</td>
-                <td className={`text-center font-bold py-2.5 px-2 ${wrColor}`}>{c.wr}%</td>
-                <td className={`text-center font-semibold py-2.5 px-2 ${kdaColor}`}>
+                <td className="text-center" style={{ color: 'var(--text-muted)', padding: '10px 8px' }}>
+                  {c.games}
+                </td>
+                <td className="text-center font-bold" style={{ color: wrColor, padding: '10px 8px' }}>
+                  {c.wr}%
+                </td>
+                <td className="text-center font-semibold" style={{ color: kdaColor, padding: '10px 8px' }}>
                   {c.kda === 'Perfect' ? '∞' : c.kda}
-                  <div className="text-[#4A5568] font-normal">
+                  <div style={{ color: 'var(--text-faint)', fontWeight: 400, fontSize: 'var(--text-xs)' }}>
                     {c.kills}/{c.deaths}/{c.assists}
                   </div>
                 </td>

--- a/components/profile/HeroBanner.tsx
+++ b/components/profile/HeroBanner.tsx
@@ -7,7 +7,7 @@ interface BorderStyle {
   glow: string;
 }
 
-interface HeroBannerProps {
+export interface HeroBannerProps {
   gameName: string;
   tagLine: string;
   level: number;
@@ -22,13 +22,18 @@ interface HeroBannerProps {
   recentWR: number;
   avgKDA: string;
   profileName?: string | null;
+  /** Nome do perfil ArenaGG vinculado (exibido como badge azul) — equivale a isLinked */
+  linkedProfileName?: string | null;
 }
 
 export function HeroBanner({
   gameName, tagLine, level, iconUrl, borderImg, borderStyle,
   mainSplash, mainChampName, totalGames, totalWins, totalLosses,
-  recentWR, avgKDA, profileName,
+  recentWR, avgKDA, profileName, linkedProfileName,
 }: HeroBannerProps) {
+  // profileName mantido por retrocompatibilidade; linkedProfileName tem precedência
+  const displayLinked = linkedProfileName ?? profileName ?? null;
+
   return (
     <div className="relative w-full overflow-hidden" style={{ minHeight: 260 }}>
       {/* Splash art do campeão principal como fundo */}
@@ -176,7 +181,7 @@ export function HeroBanner({
                 <span className="stat-pill">KDA médio {avgKDA}</span>
               </>
             )}
-            {profileName && (
+            {displayLinked && (
               <span
                 className="stat-pill"
                 style={{
@@ -186,7 +191,7 @@ export function HeroBanner({
                 }}
               >
                 <User size={12} aria-hidden="true" />
-                {profileName}
+                {displayLinked}
               </span>
             )}
           </div>

--- a/components/profile/HeroBanner.tsx
+++ b/components/profile/HeroBanner.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import { Meteors } from "@/components/ui/meteors";
+
+interface BorderStyle {
+  color: string;
+  glow: string;
+}
+
+interface HeroBannerProps {
+  gameName: string;
+  tagLine: string;
+  level: number;
+  iconUrl: string | null;
+  borderImg: string | null;
+  borderStyle: BorderStyle;
+  mainSplash: string | null;
+  mainChampName: string | null;
+  totalGames: number;
+  totalWins: number;
+  totalLosses: number;
+  recentWR: number;
+  avgKDA: string;
+  profileName?: string | null;
+}
+
+export function HeroBanner({
+  gameName, tagLine, level, iconUrl, borderImg, borderStyle,
+  mainSplash, mainChampName, totalGames, totalWins, totalLosses,
+  recentWR, avgKDA, profileName,
+}: HeroBannerProps) {
+  return (
+    <div className="relative w-full overflow-hidden" style={{ minHeight: 260 }}>
+      {/* Splash art do campeão principal como fundo */}
+      {mainSplash ? (
+        <div
+          style={{
+            position: "absolute", inset: 0,
+            backgroundImage: `url(${mainSplash})`,
+            backgroundSize: "cover",
+            backgroundPosition: "center 15%",
+            filter: "brightness(0.30) saturate(1.3)",
+          }}
+        />
+      ) : (
+        <div style={{ position: "absolute", inset: 0, background: "#050E1A" }} />
+      )}
+
+      {/* Gradientes de profundidade */}
+      <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to right, #050E1A 35%, transparent 80%)" }} />
+      <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to bottom, transparent 40%, #050E1A 100%)" }} />
+
+      {/* Meteoros */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <Meteors number={8} />
+      </div>
+
+      {/* Conteúdo */}
+      <div
+        className="relative max-w-6xl mx-auto px-4 pt-10 pb-8"
+        style={{ display: "flex", alignItems: "flex-end", gap: 24, flexWrap: "wrap" }}
+      >
+        {/* Ícone + moldura + badge de nível */}
+        <div style={{ position: "relative", width: 110, height: 126, flexShrink: 0 }}>
+          {iconUrl && (
+            <>
+              <img
+                src={iconUrl}
+                width={86}
+                height={86}
+                alt="Ícone de perfil"
+                style={{ position: "absolute", top: 12, left: 12, width: 86, height: 86, borderRadius: "50%", display: "block", zIndex: 1 }}
+              />
+              {borderImg && (
+                <img
+                  src={borderImg}
+                  width={110}
+                  height={110}
+                  alt=""
+                  aria-hidden="true"
+                  style={{ position: "absolute", top: 0, left: 0, width: 110, height: 110, display: "block", zIndex: 2, pointerEvents: "none" }}
+                />
+              )}
+              <span
+                style={{
+                  position: "absolute", bottom: 0, left: "50%", transform: "translateX(-50%)",
+                  zIndex: 3, background: "#050E1A",
+                  border: `1.5px solid ${borderStyle.color}`,
+                  color: borderStyle.color,
+                  fontSize: 11, fontWeight: 700,
+                  padding: "2px 10px",
+                  borderRadius: 9999, lineHeight: "16px",
+                  whiteSpace: "nowrap",
+                  boxShadow: `0 0 8px ${borderStyle.glow}`,
+                }}
+              >
+                Nv. {level}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Nome + stats pills */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", marginBottom: 6 }}>
+            <h1 style={{ fontSize: 28, fontWeight: 800, color: "#fff", lineHeight: 1.1, letterSpacing: "-0.5px" }}>
+              {gameName}
+            </h1>
+            <span style={{ color: "#6B7280", fontSize: 22, fontWeight: 700 }}>#{tagLine}</span>
+            {mainChampName && (
+              <span className="stat-pill">⚔️ {mainChampName}</span>
+            )}
+          </div>
+
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+            {totalGames > 0 && (
+              <>
+                <span className="stat-pill">{totalGames} jogos recentes</span>
+                <span
+                  className="stat-pill"
+                  style={{
+                    background:   recentWR >= 50 ? "rgba(74,222,128,0.1)"  : "rgba(248,113,113,0.1)",
+                    borderColor:  recentWR >= 50 ? "rgba(74,222,128,0.3)"  : "rgba(248,113,113,0.3)",
+                    color:        recentWR >= 50 ? "#4ADE80"                : "#F87171",
+                  }}
+                >
+                  {totalWins}V {totalLosses}D · {recentWR}% WR
+                </span>
+                <span className="stat-pill">KDA médio {avgKDA}</span>
+              </>
+            )}
+            {profileName && (
+              <span className="stat-pill" style={{ color: "#60A5FA", borderColor: "rgba(96,165,250,0.3)", background: "rgba(96,165,250,0.1)" }}>
+                👤 {profileName}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <Link
+          href="/jogadores"
+          style={{
+            fontSize: 13, color: "#9CA3AF",
+            border: "1px solid #1E3A5F", borderRadius: 8,
+            padding: "6px 14px",
+            background: "rgba(10,20,40,0.7)",
+            textDecoration: "none",
+            flexShrink: 0, alignSelf: "flex-start", marginTop: 4,
+          }}
+        >
+          ← Jogadores
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/profile/HeroBanner.tsx
+++ b/components/profile/HeroBanner.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Swords, User, ArrowLeft } from "lucide-react";
 import { Meteors } from "@/components/ui/meteors";
 
 interface BorderStyle {
@@ -57,7 +58,7 @@ export function HeroBanner({
       {/* Conteúdo */}
       <div
         className="relative max-w-6xl mx-auto px-4 pt-10 pb-8"
-        style={{ display: "flex", alignItems: "flex-end", gap: 24, flexWrap: "wrap" }}
+        style={{ display: "flex", alignItems: "flex-end", gap: "var(--sp-6)", flexWrap: "wrap" }}
       >
         {/* Ícone + moldura + badge de nível */}
         <div style={{ position: "relative", width: 110, height: 126, flexShrink: 0 }}>
@@ -68,6 +69,7 @@ export function HeroBanner({
                 width={86}
                 height={86}
                 alt="Ícone de perfil"
+                loading="lazy"
                 style={{ position: "absolute", top: 12, left: 12, width: 86, height: 86, borderRadius: "50%", display: "block", zIndex: 1 }}
               />
               {borderImg && (
@@ -77,6 +79,7 @@ export function HeroBanner({
                   height={110}
                   alt=""
                   aria-hidden="true"
+                  loading="lazy"
                   style={{ position: "absolute", top: 0, left: 0, width: 110, height: 110, display: "block", zIndex: 2, pointerEvents: "none" }}
                 />
               )}
@@ -88,7 +91,7 @@ export function HeroBanner({
                   color: borderStyle.color,
                   fontSize: 11, fontWeight: 700,
                   padding: "2px 10px",
-                  borderRadius: 9999, lineHeight: "16px",
+                  borderRadius: "var(--radius-full)", lineHeight: "16px",
                   whiteSpace: "nowrap",
                   boxShadow: `0 0 8px ${borderStyle.glow}`,
                 }}
@@ -101,26 +104,38 @@ export function HeroBanner({
 
         {/* Nome + stats pills */}
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", marginBottom: 6 }}>
-            <h1 style={{ fontSize: 28, fontWeight: 800, color: "#fff", lineHeight: 1.1, letterSpacing: "-0.5px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--sp-3)", flexWrap: "wrap", marginBottom: "var(--sp-2)" }}>
+            <h1
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: "var(--text-xl)",
+                fontWeight: 800,
+                color: "#fff",
+                lineHeight: 1.1,
+                letterSpacing: "-0.5px",
+              }}
+            >
               {gameName}
             </h1>
             <span style={{ color: "#6B7280", fontSize: 22, fontWeight: 700 }}>#{tagLine}</span>
             {mainChampName && (
-              <span className="stat-pill">⚔️ {mainChampName}</span>
+              <span className="stat-pill">
+                <Swords size={12} aria-hidden="true" />
+                {mainChampName}
+              </span>
             )}
           </div>
 
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <div style={{ display: "flex", gap: "var(--sp-2)", flexWrap: "wrap", alignItems: "center" }}>
             {totalGames > 0 && (
               <>
                 <span className="stat-pill">{totalGames} jogos recentes</span>
                 <span
                   className="stat-pill"
                   style={{
-                    background:   recentWR >= 50 ? "rgba(74,222,128,0.1)"  : "rgba(248,113,113,0.1)",
-                    borderColor:  recentWR >= 50 ? "rgba(74,222,128,0.3)"  : "rgba(248,113,113,0.3)",
-                    color:        recentWR >= 50 ? "#4ADE80"                : "#F87171",
+                    background:   recentWR >= 50 ? "var(--win-dim)"  : "var(--loss-dim)",
+                    borderColor:  recentWR >= 50 ? "rgba(34,197,94,0.3)"   : "rgba(239,68,68,0.3)",
+                    color:        recentWR >= 50 ? "var(--win)"              : "var(--loss)",
                   }}
                 >
                   {totalWins}V {totalLosses}D · {recentWR}% WR
@@ -130,7 +145,8 @@ export function HeroBanner({
             )}
             {profileName && (
               <span className="stat-pill" style={{ color: "#60A5FA", borderColor: "rgba(96,165,250,0.3)", background: "rgba(96,165,250,0.1)" }}>
-                👤 {profileName}
+                <User size={12} aria-hidden="true" />
+                {profileName}
               </span>
             )}
           </div>
@@ -139,15 +155,25 @@ export function HeroBanner({
         <Link
           href="/jogadores"
           style={{
-            fontSize: 13, color: "#9CA3AF",
-            border: "1px solid #1E3A5F", borderRadius: 8,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "var(--sp-2)",
+            fontSize: "var(--text-sm)",
+            color: "var(--text-muted)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
             padding: "6px 14px",
             background: "rgba(10,20,40,0.7)",
             textDecoration: "none",
-            flexShrink: 0, alignSelf: "flex-start", marginTop: 4,
+            flexShrink: 0,
+            alignSelf: "flex-start",
+            marginTop: 4,
+            transition: "border-color var(--duration) var(--ease-out), color var(--duration) var(--ease-out)",
           }}
+          className="hover:border-[var(--gold)] hover:text-[var(--gold)]"
         >
-          ← Jogadores
+          <ArrowLeft size={14} aria-hidden="true" />
+          Jogadores
         </Link>
       </div>
     </div>

--- a/components/profile/HeroBanner.tsx
+++ b/components/profile/HeroBanner.tsx
@@ -43,12 +43,12 @@ export function HeroBanner({
           }}
         />
       ) : (
-        <div style={{ position: "absolute", inset: 0, background: "#050E1A" }} />
+        <div style={{ position: "absolute", inset: 0, background: "var(--bg)" }} />
       )}
 
       {/* Gradientes de profundidade */}
-      <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to right, #050E1A 35%, transparent 80%)" }} />
-      <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to bottom, transparent 40%, #050E1A 100%)" }} />
+      <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to right, var(--bg) 35%, transparent 80%)" }} />
+      <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to bottom, transparent 40%, var(--bg) 100%)" }} />
 
       {/* Meteoros */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -70,7 +70,13 @@ export function HeroBanner({
                 height={86}
                 alt="Ícone de perfil"
                 loading="lazy"
-                style={{ position: "absolute", top: 12, left: 12, width: 86, height: 86, borderRadius: "50%", display: "block", zIndex: 1 }}
+                style={{
+                  position: "absolute", top: 12, left: 12,
+                  width: 86, height: 86,
+                  borderRadius: "50%",
+                  display: "block",
+                  zIndex: 1,
+                }}
               />
               {borderImg && (
                 <img
@@ -80,18 +86,26 @@ export function HeroBanner({
                   alt=""
                   aria-hidden="true"
                   loading="lazy"
-                  style={{ position: "absolute", top: 0, left: 0, width: 110, height: 110, display: "block", zIndex: 2, pointerEvents: "none" }}
+                  style={{
+                    position: "absolute", top: 0, left: 0,
+                    width: 110, height: 110,
+                    display: "block", zIndex: 2,
+                    pointerEvents: "none",
+                  }}
                 />
               )}
               <span
                 style={{
-                  position: "absolute", bottom: 0, left: "50%", transform: "translateX(-50%)",
-                  zIndex: 3, background: "#050E1A",
+                  position: "absolute", bottom: 0, left: "50%",
+                  transform: "translateX(-50%)",
+                  zIndex: 3,
+                  background: "var(--bg)",
                   border: `1.5px solid ${borderStyle.color}`,
                   color: borderStyle.color,
                   fontSize: 11, fontWeight: 700,
                   padding: "2px 10px",
-                  borderRadius: "var(--radius-full)", lineHeight: "16px",
+                  borderRadius: "var(--radius-full)",
+                  lineHeight: "16px",
                   whiteSpace: "nowrap",
                   boxShadow: `0 0 8px ${borderStyle.glow}`,
                 }}
@@ -104,20 +118,34 @@ export function HeroBanner({
 
         {/* Nome + stats pills */}
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: "var(--sp-3)", flexWrap: "wrap", marginBottom: "var(--sp-2)" }}>
+          <div
+            style={{
+              display: "flex", alignItems: "center",
+              gap: "var(--sp-3)", flexWrap: "wrap",
+              marginBottom: "var(--sp-2)",
+            }}
+          >
             <h1
               style={{
                 fontFamily: "var(--font-display)",
                 fontSize: "var(--text-xl)",
                 fontWeight: 800,
-                color: "#fff",
+                color: "var(--text)",
                 lineHeight: 1.1,
                 letterSpacing: "-0.5px",
               }}
             >
               {gameName}
             </h1>
-            <span style={{ color: "#6B7280", fontSize: 22, fontWeight: 700 }}>#{tagLine}</span>
+            <span
+              style={{
+                color: "var(--text-faint)",
+                fontSize: 22,
+                fontWeight: 700,
+              }}
+            >
+              #{tagLine}
+            </span>
             {mainChampName && (
               <span className="stat-pill">
                 <Swords size={12} aria-hidden="true" />
@@ -126,16 +154,21 @@ export function HeroBanner({
             )}
           </div>
 
-          <div style={{ display: "flex", gap: "var(--sp-2)", flexWrap: "wrap", alignItems: "center" }}>
+          <div
+            style={{
+              display: "flex", gap: "var(--sp-2)",
+              flexWrap: "wrap", alignItems: "center",
+            }}
+          >
             {totalGames > 0 && (
               <>
                 <span className="stat-pill">{totalGames} jogos recentes</span>
                 <span
                   className="stat-pill"
                   style={{
-                    background:   recentWR >= 50 ? "var(--win-dim)"  : "var(--loss-dim)",
-                    borderColor:  recentWR >= 50 ? "rgba(34,197,94,0.3)"   : "rgba(239,68,68,0.3)",
-                    color:        recentWR >= 50 ? "var(--win)"              : "var(--loss)",
+                    background:  recentWR >= 50 ? "var(--win-dim)"        : "var(--loss-dim)",
+                    borderColor: recentWR >= 50 ? "rgba(34,197,94,0.3)"  : "rgba(239,68,68,0.3)",
+                    color:       recentWR >= 50 ? "var(--win)"            : "var(--loss)",
                   }}
                 >
                   {totalWins}V {totalLosses}D · {recentWR}% WR
@@ -144,7 +177,14 @@ export function HeroBanner({
               </>
             )}
             {profileName && (
-              <span className="stat-pill" style={{ color: "#60A5FA", borderColor: "rgba(96,165,250,0.3)", background: "rgba(96,165,250,0.1)" }}>
+              <span
+                className="stat-pill"
+                style={{
+                  color: "var(--blue)",
+                  borderColor: "var(--blue-dim, rgba(85,145,199,0.3))",
+                  background: "var(--blue-dim, rgba(85,145,199,0.1))",
+                }}
+              >
                 <User size={12} aria-hidden="true" />
                 {profileName}
               </span>
@@ -152,6 +192,7 @@ export function HeroBanner({
           </div>
         </div>
 
+        {/* Botão voltar */}
         <Link
           href="/jogadores"
           style={{
@@ -163,7 +204,7 @@ export function HeroBanner({
             border: "1px solid var(--border)",
             borderRadius: "var(--radius-md)",
             padding: "6px 14px",
-            background: "rgba(10,20,40,0.7)",
+            background: "var(--surface)",
             textDecoration: "none",
             flexShrink: 0,
             alignSelf: "flex-start",

--- a/components/profile/MasteryGrid.tsx
+++ b/components/profile/MasteryGrid.tsx
@@ -1,0 +1,84 @@
+import { championIconByCDragon, masteryLevelColor } from "@/lib/riot";
+
+interface Mastery {
+  championId: number;
+  championLevel: number;
+  championPoints: number;
+  championName?: string;
+}
+
+interface MasteryGridProps {
+  masteries: Mastery[];
+  champById: Record<number, string>;
+}
+
+function formatPoints(pts: number): string {
+  if (pts >= 1_000_000) return `${(pts / 1_000_000).toFixed(1)}M`;
+  if (pts >= 1_000)     return `${(pts / 1_000).toFixed(0)}k`;
+  return String(pts);
+}
+
+export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
+  if (!masteries.length) return null;
+
+  return (
+    <div
+      style={{
+        background: "#0A1428",
+        border: "1px solid rgba(30,58,95,0.8)",
+        borderRadius: 16,
+        padding: 20,
+      }}
+    >
+      <p style={{ color: "#9CA3AF", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 14 }}>
+        🏆 Top Campeões — Maestria
+      </p>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+        {masteries.map((m) => {
+          const name  = champById[m.championId] ?? m.championName ?? "";
+          const color = masteryLevelColor(m.championLevel);
+          const pts   = formatPoints(m.championPoints);
+          return (
+            <div
+              key={m.championId}
+              title={`${name} — M${m.championLevel} — ${pts}`}
+              style={{
+                display: "flex", flexDirection: "column", alignItems: "center", gap: 4,
+                background: "rgba(10,20,40,0.7)",
+                border: `1.5px solid ${color}44`,
+                borderRadius: 12, padding: "10px 10px 8px", minWidth: 76,
+                transition: "transform 200ms ease, border-color 200ms ease",
+              }}
+              className="hover:scale-105"
+            >
+              <div style={{ position: "relative", width: 52, height: 52 }}>
+                <img
+                  src={championIconByCDragon(m.championId)}
+                  width={52}
+                  height={52}
+                  alt={name}
+                  style={{ width: 52, height: 52, borderRadius: 8, objectFit: "cover", display: "block", border: `2px solid ${color}` }}
+                />
+                <span
+                  style={{
+                    position: "absolute", bottom: -6, right: -6,
+                    background: "#050E1A", border: `1px solid ${color}`,
+                    color, fontSize: 9, fontWeight: 800,
+                    borderRadius: 9999, padding: "1px 5px", lineHeight: "14px",
+                    whiteSpace: "nowrap", zIndex: 2,
+                  }}
+                >
+                  M{m.championLevel}
+                </span>
+              </div>
+              <p style={{ fontSize: 11, color: "#D1D5DB", maxWidth: 72, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", textAlign: "center", marginTop: 8 }}>
+                {name}
+              </p>
+              <p style={{ fontSize: 11, color, fontWeight: 700, textAlign: "center" }}>{pts}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/profile/MasteryGrid.tsx
+++ b/components/profile/MasteryGrid.tsx
@@ -23,33 +23,10 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
   if (!masteries.length) return null;
 
   return (
-    <div
-      style={{
-        background: "var(--surface)",
-        border: "1px solid var(--border)",
-        borderRadius: "var(--radius-lg)",
-        padding: "var(--sp-5)",
-      }}
-    >
-      {/* Header da seção — sem emoji */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "var(--sp-2)",
-          marginBottom: "var(--sp-4)",
-        }}
-      >
+    <div className="card">
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--sp-2)", marginBottom: "var(--sp-4)" }}>
         <Trophy size={14} style={{ color: "var(--gold)" }} aria-hidden="true" />
-        <p
-          style={{
-            color: "var(--text-muted)",
-            fontSize: "var(--text-xs)",
-            fontWeight: 700,
-            textTransform: "uppercase",
-            letterSpacing: "0.1em",
-          }}
-        >
+        <p style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em" }}>
           Top Campeões — Maestria
         </p>
       </div>
@@ -63,16 +40,8 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
             <div
               key={m.championId}
               title={`${name} — M${m.championLevel} — ${pts}`}
-              style={{
-                display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--sp-1)",
-                background: "rgba(10,20,40,0.7)",
-                border: `1.5px solid ${color}44`,
-                borderRadius: "var(--radius-md)",
-                padding: "10px 10px 8px",
-                minWidth: 76,
-                transition: "transform 200ms var(--ease-out), border-color 200ms var(--ease-out)",
-              }}
-              className="hover:scale-105"
+              className="mastery-card"
+              style={{ border: `1.5px solid ${color}44` }}
             >
               <div style={{ position: "relative", width: 52, height: 52 }}>
                 <img
@@ -81,15 +50,30 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
                   height={52}
                   alt={name}
                   loading="lazy"
-                  style={{ width: 52, height: 52, borderRadius: "var(--radius-sm)", objectFit: "cover", display: "block", border: `2px solid ${color}` }}
+                  style={{
+                    width: 52,
+                    height: 52,
+                    borderRadius: "var(--radius-sm)",
+                    objectFit: "cover",
+                    display: "block",
+                    border: `2px solid ${color}`,
+                  }}
                 />
                 <span
                   style={{
-                    position: "absolute", bottom: -6, right: -6,
-                    background: "#050E1A", border: `1px solid ${color}`,
-                    color, fontSize: 9, fontWeight: 800,
-                    borderRadius: "var(--radius-full)", padding: "1px 5px", lineHeight: "14px",
-                    whiteSpace: "nowrap", zIndex: 2,
+                    position: "absolute",
+                    bottom: -6,
+                    right: -6,
+                    background: "var(--bg)",
+                    border: `1px solid ${color}`,
+                    color,
+                    fontSize: "var(--text-xs)",
+                    fontWeight: 800,
+                    borderRadius: "var(--radius-full)",
+                    padding: "1px 5px",
+                    lineHeight: "14px",
+                    whiteSpace: "nowrap",
+                    zIndex: 2,
                   }}
                 >
                   M{m.championLevel}
@@ -109,7 +93,9 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
               >
                 {name}
               </p>
-              <p style={{ fontSize: "var(--text-xs)", color, fontWeight: 700, textAlign: "center" }}>{pts}</p>
+              <p style={{ fontSize: "var(--text-xs)", color, fontWeight: 700, textAlign: "center" }}>
+                {pts}
+              </p>
             </div>
           );
         })}

--- a/components/profile/MasteryGrid.tsx
+++ b/components/profile/MasteryGrid.tsx
@@ -1,3 +1,4 @@
+import { Trophy } from "lucide-react";
 import { championIconByCDragon, masteryLevelColor } from "@/lib/riot";
 
 interface Mastery {
@@ -24,16 +25,36 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
   return (
     <div
       style={{
-        background: "#0A1428",
-        border: "1px solid rgba(30,58,95,0.8)",
-        borderRadius: 16,
-        padding: 20,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-lg)",
+        padding: "var(--sp-5)",
       }}
     >
-      <p style={{ color: "#9CA3AF", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 14 }}>
-        🏆 Top Campeões — Maestria
-      </p>
-      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+      {/* Header da seção — sem emoji */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--sp-2)",
+          marginBottom: "var(--sp-4)",
+        }}
+      >
+        <Trophy size={14} style={{ color: "var(--gold)" }} aria-hidden="true" />
+        <p
+          style={{
+            color: "var(--text-muted)",
+            fontSize: "var(--text-xs)",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+          }}
+        >
+          Top Campeões — Maestria
+        </p>
+      </div>
+
+      <div style={{ display: "flex", gap: "var(--sp-3)", flexWrap: "wrap" }}>
         {masteries.map((m) => {
           const name  = champById[m.championId] ?? m.championName ?? "";
           const color = masteryLevelColor(m.championLevel);
@@ -43,11 +64,13 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
               key={m.championId}
               title={`${name} — M${m.championLevel} — ${pts}`}
               style={{
-                display: "flex", flexDirection: "column", alignItems: "center", gap: 4,
+                display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--sp-1)",
                 background: "rgba(10,20,40,0.7)",
                 border: `1.5px solid ${color}44`,
-                borderRadius: 12, padding: "10px 10px 8px", minWidth: 76,
-                transition: "transform 200ms ease, border-color 200ms ease",
+                borderRadius: "var(--radius-md)",
+                padding: "10px 10px 8px",
+                minWidth: 76,
+                transition: "transform 200ms var(--ease-out), border-color 200ms var(--ease-out)",
               }}
               className="hover:scale-105"
             >
@@ -57,24 +80,36 @@ export function MasteryGrid({ masteries, champById }: MasteryGridProps) {
                   width={52}
                   height={52}
                   alt={name}
-                  style={{ width: 52, height: 52, borderRadius: 8, objectFit: "cover", display: "block", border: `2px solid ${color}` }}
+                  loading="lazy"
+                  style={{ width: 52, height: 52, borderRadius: "var(--radius-sm)", objectFit: "cover", display: "block", border: `2px solid ${color}` }}
                 />
                 <span
                   style={{
                     position: "absolute", bottom: -6, right: -6,
                     background: "#050E1A", border: `1px solid ${color}`,
                     color, fontSize: 9, fontWeight: 800,
-                    borderRadius: 9999, padding: "1px 5px", lineHeight: "14px",
+                    borderRadius: "var(--radius-full)", padding: "1px 5px", lineHeight: "14px",
                     whiteSpace: "nowrap", zIndex: 2,
                   }}
                 >
                   M{m.championLevel}
                 </span>
               </div>
-              <p style={{ fontSize: 11, color: "#D1D5DB", maxWidth: 72, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", textAlign: "center", marginTop: 8 }}>
+              <p
+                style={{
+                  fontSize: "var(--text-xs)",
+                  color: "var(--text)",
+                  maxWidth: 72,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  textAlign: "center",
+                  marginTop: "var(--sp-2)",
+                }}
+              >
                 {name}
               </p>
-              <p style={{ fontSize: 11, color, fontWeight: 700, textAlign: "center" }}>{pts}</p>
+              <p style={{ fontSize: "var(--text-xs)", color, fontWeight: 700, textAlign: "center" }}>{pts}</p>
             </div>
           );
         })}

--- a/components/profile/MatchHistoryRow.tsx
+++ b/components/profile/MatchHistoryRow.tsx
@@ -1,6 +1,20 @@
 'use client';
 import Image from 'next/image';
 
+// URL base CommunityDragon — padrão do projeto (não usar DDragon)
+const CDN_CHAMPION = (championName: string) =>
+  `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons-by-name/${championName.toLowerCase()}.png`;
+
+// Itens: DDragon não tem CORS issue para itens e CDragon não expõe por ID direto — manter CDragon via sprite
+// CommunityDragon expõe itens em: /latest/plugins/rcp-be-lol-game-data/global/default/assets/items/icons2d/{itemId}.png
+// Mas o nome do arquivo é o displayName, não o ID numérico. A alternativa estável é o endpoint de items JSON.
+// Por isso usamos a URL pública: https://raw.communitydragon.org/latest/game/assets/items/icons2d/{hex}.png
+// A forma mais simples e sem DD_VERSION: API de itens do CDragon via ID
+const CDN_ITEM = (id: number) =>
+  `https://ddragon.leagueoflegends.com/cdn/15.10.1/img/item/${id}.png`;
+// NOTA: item CDN via DDragon usa versão pinada (15.10.1) até que tenhamos endpoint CDragon estável por ID.
+// Isso elimina a necessidade de getDDVersion() em runtime — versão pinada só muda a cada patch maior.
+
 const POSITION_LABEL: Record<string, string> = {
   TOP: 'Top',
   JUNGLE: 'Jungle',
@@ -21,7 +35,6 @@ interface Props {
   teamPosition: string;
   cs?: number;
   vision?: number;
-  DD_VERSION: string;
   items?: number[];
 }
 
@@ -36,7 +49,6 @@ export default function MatchHistoryRow({
   teamPosition,
   cs = 0,
   vision = 0,
-  DD_VERSION,
   items = [],
 }: Props) {
   const minutes = Math.floor(gameDuration / 60);
@@ -49,48 +61,71 @@ export default function MatchHistoryRow({
     kdaNum >= 2 ? 'text-[#A0AEC0]' : 'text-[#FC8181]';
   const posLabel = POSITION_LABEL[teamPosition] ?? (gameMode === 'ARAM' ? 'ARAM' : gameMode);
 
+  // Gradiente sutil por resultado — sem border-left colorido
+  const containerStyle: React.CSSProperties = win
+    ? {
+        background: 'linear-gradient(135deg, rgba(59,130,246,0.08) 0%, var(--surface) 40%)',
+        border: '1px solid rgba(59,130,246,0.25)',
+        borderRadius: 'var(--radius-lg)',
+      }
+    : {
+        background: 'linear-gradient(135deg, rgba(239,68,68,0.08) 0%, var(--surface) 40%)',
+        border: '1px solid rgba(239,68,68,0.20)',
+        borderRadius: 'var(--radius-lg)',
+      };
+
   return (
     <div
-      className={`group flex items-center gap-4 rounded-xl px-4 py-3 border-l-[4px] transition-all duration-200 ${
-        win
-          ? 'bg-[#0D1E35]/80 border-l-[#3B82F6] hover:bg-[#101E35] border-y border-r border-[#1E3A5F]'
-          : 'bg-[#1E0D0D]/80 border-l-[#EF4444] hover:bg-[#1E1010] border-y border-r border-[#3D1414]'
-      }`}
+      className="group flex items-center gap-4 px-4 py-3 transition-all duration-200 hover:brightness-110"
+      style={containerStyle}
     >
-      {/* Info básica + Campeão */}
+      {/* Campeão + resultado */}
       <div className="flex items-center gap-3 min-w-[140px]">
         <div className="relative flex-shrink-0">
           <Image
-            src={`https://ddragon.leagueoflegends.com/cdn/${DD_VERSION}/img/champion/${championName}.png`}
+            src={CDN_CHAMPION(championName)}
             width={48}
             height={48}
             alt={championName}
-            className="rounded-xl border-2 border-[#1E3A5F] object-cover"
+            className="rounded-xl object-cover"
+            style={{ border: '2px solid var(--border)' }}
+            onError={(e) => {
+              // fallback: CDragon icon genérico se nome não bater
+              (e.currentTarget as HTMLImageElement).src =
+                'https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/-1.png';
+            }}
           />
           <span
-            className={`absolute -bottom-1 -right-1 text-[10px] font-black px-1.5 py-0.5 rounded shadow-lg ${
-              win ? 'bg-[#3B82F6] text-white' : 'bg-[#EF4444] text-white'
-            }`}
+            className="absolute -bottom-1 -right-1 font-black px-1.5 py-0.5 rounded shadow-lg"
+            style={{
+              fontSize: 'var(--text-xs)',
+              background: win ? 'var(--blue)' : 'var(--loss)',
+              color: '#fff',
+            }}
           >
             {win ? 'V' : 'D'}
           </span>
         </div>
         <div className="overflow-hidden">
-          <p className="text-white text-sm font-bold truncate leading-none">{championName}</p>
-          <p className="text-[#718096] text-[11px] mt-1 font-medium">{posLabel}</p>
+          <p style={{ color: 'var(--text)', fontSize: 'var(--text-sm)', fontWeight: 700 }} className="truncate leading-none">
+            {championName}
+          </p>
+          <p style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }} className="mt-1 font-medium">
+            {posLabel}
+          </p>
         </div>
       </div>
 
       {/* KDA */}
       <div className="w-24 text-center">
-        <p className="text-white text-base font-black tracking-tighter">
+        <p style={{ color: 'var(--text)', fontSize: 'var(--text-base)', fontWeight: 900 }} className="tracking-tighter">
           <span>{kills}</span>
-          <span className="text-[#4A5568] mx-1">/</span>
-          <span className="text-[#EF4444]">{deaths}</span>
-          <span className="text-[#4A5568] mx-1">/</span>
-          <span className="text-[#A0AEC0]">{assists}</span>
+          <span style={{ color: 'var(--text-faint)' }} className="mx-1">/</span>
+          <span style={{ color: 'var(--loss)' }}>{deaths}</span>
+          <span style={{ color: 'var(--text-faint)' }} className="mx-1">/</span>
+          <span style={{ color: 'var(--text-muted)' }}>{assists}</span>
         </p>
-        <p className={`text-[11px] font-bold mt-0.5 ${kdaColor}`}>
+        <p className={`font-bold mt-0.5 ${kdaColor}`} style={{ fontSize: 'var(--text-xs)' }}>
           {kda === 'Perfect' ? '⭐ PERFECT' : `${kda} KDA`}
         </p>
       </div>
@@ -98,11 +133,18 @@ export default function MatchHistoryRow({
       {/* Items */}
       <div className="flex-1 flex gap-1 justify-center">
         {items.map((id, idx) => (
-          <div key={idx} className="w-8 h-8 rounded-md bg-black/40 border border-[#1E3A5F] overflow-hidden">
+          <div
+            key={idx}
+            className="w-8 h-8 rounded-md overflow-hidden"
+            style={{ background: 'rgba(0,0,0,0.4)', border: '1px solid var(--border)' }}
+          >
             {id > 0 && (
               <img
-                src={`https://ddragon.leagueoflegends.com/cdn/${DD_VERSION}/img/item/${id}.png`}
+                src={CDN_ITEM(id)}
                 alt={`Item ${id}`}
+                width={32}
+                height={32}
+                loading="lazy"
                 className="w-full h-full object-cover"
               />
             )}
@@ -112,16 +154,20 @@ export default function MatchHistoryRow({
 
       {/* CS + Visão */}
       <div className="text-center hidden md:block w-20 flex-shrink-0">
-        <p className="text-[#A0AEC0] text-sm font-bold">{cs} CS</p>
-        <p className="text-[#718096] text-[11px] font-medium">({(cs / (gameDuration / 60)).toFixed(1)}/m)</p>
+        <p style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)', fontWeight: 700 }}>{cs} CS</p>
+        <p style={{ color: 'var(--text-faint)', fontSize: 'var(--text-xs)', fontWeight: 500 }}>
+          ({(cs / (gameDuration / 60)).toFixed(1)}/m)
+        </p>
       </div>
 
       {/* Duração */}
       <div className="text-right flex-shrink-0 w-16">
-        <p className="text-white text-sm font-bold">
+        <p style={{ color: 'var(--text)', fontSize: 'var(--text-sm)', fontWeight: 700 }}>
           {minutes}:{seconds.toString().padStart(2, '0')}
         </p>
-        <p className="text-[#4A5568] text-[11px] font-black mt-0.5 truncate uppercase tracking-tighter">{gameMode}</p>
+        <p style={{ color: 'var(--text-faint)', fontSize: 'var(--text-xs)', fontWeight: 900 }} className="mt-0.5 truncate uppercase tracking-tighter">
+          {gameMode}
+        </p>
       </div>
     </div>
   );

--- a/components/profile/MatchRow.tsx
+++ b/components/profile/MatchRow.tsx
@@ -1,0 +1,145 @@
+import { championIconByCDragon } from "@/lib/riot";
+
+const QUEUE_NAMES: Record<number, string> = {
+  420: "Solo/Duo", 440: "Flex 5v5", 450: "ARAM",
+  400: "Normal Draft", 430: "Normal Cega", 0: "Custom",
+};
+
+const POSITION_PT: Record<string, string> = {
+  TOP: "Top", JUNGLE: "Jungle", MIDDLE: "Mid",
+  BOTTOM: "ADC", UTILITY: "Sup", NONE: "—",
+};
+
+function itemIconUrl(ddVersion: string, itemId: number): string {
+  if (!itemId || itemId === 0) return "";
+  return `https://ddragon.leagueoflegends.com/cdn/${ddVersion}/img/item/${itemId}.png`;
+}
+
+function fmtDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s.toString().padStart(2, "0")}s`;
+}
+
+function timeAgo(ts: number): string {
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60)    return `${diff}s atrás`;
+  if (diff < 3600)  return `${Math.floor(diff / 60)}min atrás`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h atrás`;
+  return `${Math.floor(diff / 86400)}d atrás`;
+}
+
+interface MatchRowProps {
+  matchId: string;
+  win: boolean;
+  championId: number;
+  championName: string;
+  kills: number;
+  deaths: number;
+  assists: number;
+  teamPosition: string;
+  individualPosition: string;
+  items: number[];
+  queueId: number;
+  gameDuration: number;
+  gameStartTimestamp: number;
+  pentaKills: number;
+  ddVersion: string;
+  champById: Record<number, string>;
+}
+
+export function MatchRow({
+  matchId, win, championId, championName, kills, deaths, assists,
+  teamPosition, individualPosition, items, queueId, gameDuration,
+  gameStartTimestamp, pentaKills, ddVersion, champById,
+}: MatchRowProps) {
+  const kda       = ((kills + assists) / Math.max(1, deaths)).toFixed(2);
+  const champName = champById[championId] ?? championName;
+  const queueName = QUEUE_NAMES[queueId] ?? `Fila ${queueId}`;
+  const pos       = POSITION_PT[teamPosition] ?? POSITION_PT[individualPosition] ?? "—";
+
+  return (
+    <div
+      key={matchId}
+      className="match-row"
+      style={{
+        display: "flex", alignItems: "center", gap: 12,
+        padding: "12px 16px",
+        borderBottom: "1px solid rgba(30,58,95,0.4)",
+        transition: "background 0.15s",
+        /* Substituindo border-left colorido por fundo gradiente sutil */
+        background: win
+          ? "linear-gradient(90deg, rgba(34,197,94,0.06) 0%, transparent 20%)"
+          : "linear-gradient(90deg, rgba(239,68,68,0.06) 0%, transparent 20%)",
+        borderLeft: `3px solid ${win ? "#22C55E" : "#EF4444"}44`,
+      }}
+    >
+      {/* V/D */}
+      <div style={{ width: 32, flexShrink: 0, textAlign: "center", fontSize: 12, fontWeight: 800, color: win ? "#4ADE80" : "#F87171" }}>
+        {win ? "V" : "D"}
+      </div>
+
+      {/* Ícone campeão + posição */}
+      <div style={{ position: "relative", flexShrink: 0 }}>
+        <img
+          src={championIconByCDragon(championId)}
+          width={44}
+          height={44}
+          alt={champName}
+          style={{ width: 44, height: 44, borderRadius: 8, objectFit: "cover", display: "block", border: `2px solid ${win ? "#22C55E44" : "#EF444444"}` }}
+        />
+        {pos !== "—" && (
+          <span
+            style={{
+              position: "absolute", bottom: -4, right: -4,
+              background: "#050E1A", fontSize: 8, fontWeight: 700,
+              color: "#C8A84B", border: "1px solid #1E3A5F",
+              borderRadius: 4, padding: "1px 3px", lineHeight: 1.2,
+            }}
+          >
+            {pos}
+          </span>
+        )}
+      </div>
+
+      {/* KDA */}
+      <div style={{ minWidth: 90, flexShrink: 0 }}>
+        <p style={{ fontSize: 14, fontWeight: 700, color: "#fff", lineHeight: 1 }}>
+          {kills} / <span style={{ color: "#F87171" }}>{deaths}</span> / {assists}
+        </p>
+        <p style={{ fontSize: 11, color: "#9CA3AF", marginTop: 2 }}>
+          KDA <span style={{ color: Number(kda) >= 3 ? "#4ADE80" : "#9CA3AF", fontWeight: 700 }}>{kda}</span>
+        </p>
+      </div>
+
+      {/* Itens */}
+      <div style={{ display: "flex", gap: 3, flexShrink: 0, flexWrap: "wrap", maxWidth: 180 }}>
+        {items.map((itemId, idx) => (
+          <div
+            key={idx}
+            style={{
+              width: 24, height: 24,
+              background: itemId ? "#0A1E38" : "rgba(30,58,95,0.3)",
+              borderRadius: 4, overflow: "hidden",
+              border: "1px solid rgba(30,58,95,0.6)",
+              flexShrink: 0,
+            }}
+          >
+            {itemId > 0 && (
+              <img src={itemIconUrl(ddVersion, itemId)} width={24} height={24} alt="" style={{ width: 24, height: 24, display: "block" }} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Metadados */}
+      <div style={{ marginLeft: "auto", textAlign: "right", flexShrink: 0 }}>
+        <p style={{ fontSize: 11, color: "#9CA3AF", lineHeight: 1 }}>{queueName}</p>
+        <p style={{ fontSize: 11, color: "#6B7280", marginTop: 2 }}>{fmtDuration(gameDuration)} · {timeAgo(gameStartTimestamp)}</p>
+        {pentaKills > 0 && (
+          <p style={{ fontSize: 11, color: "#FFD700", fontWeight: 700, marginTop: 2 }}>PENTA KILL 🎉</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/profile/MatchRow.tsx
+++ b/components/profile/MatchRow.tsx
@@ -11,9 +11,12 @@ const POSITION_PT: Record<string, string> = {
   BOTTOM: "ADC", UTILITY: "Sup", NONE: "—",
 };
 
-function itemIconUrl(ddVersion: string, itemId: number): string {
+// Itens: DDragon com versão pinada (15.10.1) — elimina getDDVersion() em runtime.
+// Atualizar pin a cada patch maior. CDragon não expõe itens por ID numérico de forma estável.
+const ITEM_CDN_VERSION = "15.10.1";
+function itemIconUrl(itemId: number): string {
   if (!itemId || itemId === 0) return "";
-  return `https://ddragon.leagueoflegends.com/cdn/${ddVersion}/img/item/${itemId}.png`;
+  return `https://ddragon.leagueoflegends.com/cdn/${ITEM_CDN_VERSION}/img/item/${itemId}.png`;
 }
 
 function fmtDuration(seconds: number): string {
@@ -45,57 +48,54 @@ interface MatchRowProps {
   gameDuration: number;
   gameStartTimestamp: number;
   pentaKills: number;
-  ddVersion: string;
+  // ddVersion removido — PR14: item CDN usa versão pinada internamente
   champById: Record<number, string>;
 }
 
 export function MatchRow({
   matchId, win, championId, championName, kills, deaths, assists,
   teamPosition, individualPosition, items, queueId, gameDuration,
-  gameStartTimestamp, pentaKills, ddVersion, champById,
+  gameStartTimestamp, pentaKills, champById,
 }: MatchRowProps) {
   const kda       = ((kills + assists) / Math.max(1, deaths)).toFixed(2);
   const champName = champById[championId] ?? championName;
   const queueName = QUEUE_NAMES[queueId] ?? `Fila ${queueId}`;
   const pos       = POSITION_PT[teamPosition] ?? POSITION_PT[individualPosition] ?? "—";
 
+  // Gradiente sutil por resultado — sem border-left colorida (padrão PR13)
+  const rowStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    padding: "12px 16px",
+    borderBottom: "1px solid var(--border-soft, rgba(30,58,95,0.4))",
+    transition: "background 150ms ease",
+    background: win
+      ? "linear-gradient(135deg, rgba(34,197,94,0.07) 0%, var(--surface) 40%)"
+      : "linear-gradient(135deg, rgba(239,68,68,0.07) 0%, var(--surface) 40%)",
+    border: win
+      ? "1px solid rgba(34,197,94,0.18)"
+      : "1px solid rgba(239,68,68,0.15)",
+  };
+
   return (
     <div
       key={matchId}
-      className="match-row"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        padding: "12px 16px",
-        borderBottom: "1px solid var(--border-soft, rgba(30,58,95,0.4))",
-        transition: "background var(--ease-default, 0.15s ease)",
-        background: win
-          ? "linear-gradient(90deg, rgba(34,197,94,0.06) 0%, transparent 20%)"
-          : "linear-gradient(90deg, rgba(239,68,68,0.06) 0%, transparent 20%)",
-        borderLeft: `3px solid ${win ? "rgba(34,197,94,0.27)" : "rgba(239,68,68,0.27)"}`,
-      }}
-      onMouseEnter={(e) => {
-        (e.currentTarget as HTMLDivElement).style.background = "rgba(30,58,95,0.35)";
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLDivElement).style.background = win
-          ? "linear-gradient(90deg, rgba(34,197,94,0.06) 0%, transparent 20%)"
-          : "linear-gradient(90deg, rgba(239,68,68,0.06) 0%, transparent 20%)";
-      }}
+      className="match-row group"
+      style={rowStyle}
     >
       {/* V/D */}
       <div
         style={{
           width: 32, flexShrink: 0, textAlign: "center",
-          fontSize: 12, fontWeight: 800,
+          fontSize: "var(--text-xs)", fontWeight: 800,
           color: win ? "var(--win)" : "var(--loss)",
         }}
       >
         {win ? "V" : "D"}
       </div>
 
-      {/* Ícone campeão + posição */}
+      {/* Ícone campeão — CommunityDragon por championId */}
       <div style={{ position: "relative", flexShrink: 0 }}>
         <img
           src={championIconByCDragon(championId)}
@@ -105,7 +105,7 @@ export function MatchRow({
           style={{
             width: 44, height: 44, borderRadius: 8,
             objectFit: "cover", display: "block",
-            border: `2px solid ${win ? "rgba(34,197,94,0.27)" : "rgba(239,68,68,0.27)"}`,
+            border: `2px solid ${ win ? "rgba(34,197,94,0.3)" : "rgba(239,68,68,0.3)" }`,
           }}
         />
         {pos !== "—" && (
@@ -113,7 +113,8 @@ export function MatchRow({
             style={{
               position: "absolute", bottom: -4, right: -4,
               background: "var(--bg)",
-              fontSize: 8, fontWeight: 700,
+              fontSize: "var(--text-xs)", // era 8px — corrigido para 12px mínimo (PR14)
+              fontWeight: 700,
               color: "var(--gold)",
               border: "1px solid var(--border)",
               borderRadius: 4, padding: "1px 3px", lineHeight: 1.2,
@@ -126,10 +127,10 @@ export function MatchRow({
 
       {/* KDA */}
       <div style={{ minWidth: 90, flexShrink: 0 }}>
-        <p style={{ fontSize: 14, fontWeight: 700, color: "var(--text)", lineHeight: 1 }}>
+        <p style={{ fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--text)", lineHeight: 1 }}>
           {kills} / <span style={{ color: "var(--loss)" }}>{deaths}</span> / {assists}
         </p>
-        <p style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+        <p style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
           KDA{" "}
           <span
             style={{
@@ -142,7 +143,7 @@ export function MatchRow({
         </p>
       </div>
 
-      {/* Itens */}
+      {/* Itens — DDragon versão pinada, sem prop ddVersion */}
       <div style={{ display: "flex", gap: 3, flexShrink: 0, flexWrap: "wrap", maxWidth: 180 }}>
         {items.map((itemId, idx) => (
           <div
@@ -157,10 +158,11 @@ export function MatchRow({
           >
             {itemId > 0 && (
               <img
-                src={itemIconUrl(ddVersion, itemId)}
+                src={itemIconUrl(itemId)}
                 width={24}
                 height={24}
                 alt=""
+                loading="lazy"
                 style={{ width: 24, height: 24, display: "block" }}
               />
             )}
@@ -170,15 +172,15 @@ export function MatchRow({
 
       {/* Metadados */}
       <div style={{ marginLeft: "auto", textAlign: "right", flexShrink: 0 }}>
-        <p style={{ fontSize: 11, color: "var(--text-muted)", lineHeight: 1 }}>{queueName}</p>
-        <p style={{ fontSize: 11, color: "var(--text-faint)", marginTop: 2 }}>
+        <p style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", lineHeight: 1 }}>{queueName}</p>
+        <p style={{ fontSize: "var(--text-xs)", color: "var(--text-faint)", marginTop: 2 }}>
           {fmtDuration(gameDuration)} · {timeAgo(gameStartTimestamp)}
         </p>
         {pentaKills > 0 && (
           <p
             style={{
               display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 3,
-              fontSize: 11, color: "var(--gold)", fontWeight: 700, marginTop: 2,
+              fontSize: "var(--text-xs)", color: "var(--gold)", fontWeight: 700, marginTop: 2,
             }}
           >
             <Zap size={11} />

--- a/components/profile/MatchRow.tsx
+++ b/components/profile/MatchRow.tsx
@@ -1,4 +1,5 @@
 import { championIconByCDragon } from "@/lib/riot";
+import { Zap } from "lucide-react";
 
 const QUEUE_NAMES: Record<number, string> = {
   420: "Solo/Duo", 440: "Flex 5v5", 450: "ARAM",
@@ -63,19 +64,34 @@ export function MatchRow({
       key={matchId}
       className="match-row"
       style={{
-        display: "flex", alignItems: "center", gap: 12,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
         padding: "12px 16px",
-        borderBottom: "1px solid rgba(30,58,95,0.4)",
-        transition: "background 0.15s",
-        /* Substituindo border-left colorido por fundo gradiente sutil */
+        borderBottom: "1px solid var(--border-soft, rgba(30,58,95,0.4))",
+        transition: "background var(--ease-default, 0.15s ease)",
         background: win
           ? "linear-gradient(90deg, rgba(34,197,94,0.06) 0%, transparent 20%)"
           : "linear-gradient(90deg, rgba(239,68,68,0.06) 0%, transparent 20%)",
-        borderLeft: `3px solid ${win ? "#22C55E" : "#EF4444"}44`,
+        borderLeft: `3px solid ${win ? "rgba(34,197,94,0.27)" : "rgba(239,68,68,0.27)"}`,
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLDivElement).style.background = "rgba(30,58,95,0.35)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLDivElement).style.background = win
+          ? "linear-gradient(90deg, rgba(34,197,94,0.06) 0%, transparent 20%)"
+          : "linear-gradient(90deg, rgba(239,68,68,0.06) 0%, transparent 20%)";
       }}
     >
       {/* V/D */}
-      <div style={{ width: 32, flexShrink: 0, textAlign: "center", fontSize: 12, fontWeight: 800, color: win ? "#4ADE80" : "#F87171" }}>
+      <div
+        style={{
+          width: 32, flexShrink: 0, textAlign: "center",
+          fontSize: 12, fontWeight: 800,
+          color: win ? "var(--win)" : "var(--loss)",
+        }}
+      >
         {win ? "V" : "D"}
       </div>
 
@@ -86,14 +102,20 @@ export function MatchRow({
           width={44}
           height={44}
           alt={champName}
-          style={{ width: 44, height: 44, borderRadius: 8, objectFit: "cover", display: "block", border: `2px solid ${win ? "#22C55E44" : "#EF444444"}` }}
+          style={{
+            width: 44, height: 44, borderRadius: 8,
+            objectFit: "cover", display: "block",
+            border: `2px solid ${win ? "rgba(34,197,94,0.27)" : "rgba(239,68,68,0.27)"}`,
+          }}
         />
         {pos !== "—" && (
           <span
             style={{
               position: "absolute", bottom: -4, right: -4,
-              background: "#050E1A", fontSize: 8, fontWeight: 700,
-              color: "#C8A84B", border: "1px solid #1E3A5F",
+              background: "var(--bg)",
+              fontSize: 8, fontWeight: 700,
+              color: "var(--gold)",
+              border: "1px solid var(--border)",
               borderRadius: 4, padding: "1px 3px", lineHeight: 1.2,
             }}
           >
@@ -104,11 +126,19 @@ export function MatchRow({
 
       {/* KDA */}
       <div style={{ minWidth: 90, flexShrink: 0 }}>
-        <p style={{ fontSize: 14, fontWeight: 700, color: "#fff", lineHeight: 1 }}>
-          {kills} / <span style={{ color: "#F87171" }}>{deaths}</span> / {assists}
+        <p style={{ fontSize: 14, fontWeight: 700, color: "var(--text)", lineHeight: 1 }}>
+          {kills} / <span style={{ color: "var(--loss)" }}>{deaths}</span> / {assists}
         </p>
-        <p style={{ fontSize: 11, color: "#9CA3AF", marginTop: 2 }}>
-          KDA <span style={{ color: Number(kda) >= 3 ? "#4ADE80" : "#9CA3AF", fontWeight: 700 }}>{kda}</span>
+        <p style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+          KDA{" "}
+          <span
+            style={{
+              color: Number(kda) >= 3 ? "var(--win)" : "var(--text-muted)",
+              fontWeight: 700,
+            }}
+          >
+            {kda}
+          </span>
         </p>
       </div>
 
@@ -119,14 +149,20 @@ export function MatchRow({
             key={idx}
             style={{
               width: 24, height: 24,
-              background: itemId ? "#0A1E38" : "rgba(30,58,95,0.3)",
+              background: itemId ? "var(--surface-2)" : "var(--border-soft, rgba(30,58,95,0.3))",
               borderRadius: 4, overflow: "hidden",
-              border: "1px solid rgba(30,58,95,0.6)",
+              border: "1px solid var(--border)",
               flexShrink: 0,
             }}
           >
             {itemId > 0 && (
-              <img src={itemIconUrl(ddVersion, itemId)} width={24} height={24} alt="" style={{ width: 24, height: 24, display: "block" }} />
+              <img
+                src={itemIconUrl(ddVersion, itemId)}
+                width={24}
+                height={24}
+                alt=""
+                style={{ width: 24, height: 24, display: "block" }}
+              />
             )}
           </div>
         ))}
@@ -134,10 +170,20 @@ export function MatchRow({
 
       {/* Metadados */}
       <div style={{ marginLeft: "auto", textAlign: "right", flexShrink: 0 }}>
-        <p style={{ fontSize: 11, color: "#9CA3AF", lineHeight: 1 }}>{queueName}</p>
-        <p style={{ fontSize: 11, color: "#6B7280", marginTop: 2 }}>{fmtDuration(gameDuration)} · {timeAgo(gameStartTimestamp)}</p>
+        <p style={{ fontSize: 11, color: "var(--text-muted)", lineHeight: 1 }}>{queueName}</p>
+        <p style={{ fontSize: 11, color: "var(--text-faint)", marginTop: 2 }}>
+          {fmtDuration(gameDuration)} · {timeAgo(gameStartTimestamp)}
+        </p>
         {pentaKills > 0 && (
-          <p style={{ fontSize: 11, color: "#FFD700", fontWeight: 700, marginTop: 2 }}>PENTA KILL 🎉</p>
+          <p
+            style={{
+              display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 3,
+              fontSize: 11, color: "var(--gold)", fontWeight: 700, marginTop: 2,
+            }}
+          >
+            <Zap size={11} />
+            PENTA KILL
+          </p>
         )}
       </div>
     </div>

--- a/components/profile/PlayerCard.tsx
+++ b/components/profile/PlayerCard.tsx
@@ -1,39 +1,39 @@
 import React from 'react';
 import Link from 'next/link';
 
-const TIER_COLORS: Record<string, string> = {
-  IRON: 'text-gray-400',
-  BRONZE: 'text-amber-700',
-  SILVER: 'text-gray-300',
-  GOLD: 'text-yellow-400',
-  PLATINUM: 'text-teal-400',
-  EMERALD: 'text-emerald-400',
-  DIAMOND: 'text-blue-400',
-  MASTER: 'text-purple-400',
-  GRANDMASTER: 'text-red-400',
-  CHALLENGER: 'text-yellow-300',
+// Mapeamento tier → cor usando tokens CSS definidos em globals.css
+const TIER_COLOR_VAR: Record<string, string> = {
+  IRON:         'var(--text-muted)',
+  BRONZE:       '#CD7F32',
+  SILVER:       'var(--text-muted)',
+  GOLD:         'var(--gold)',
+  PLATINUM:     '#4FC3C3',
+  EMERALD:      '#50C878',
+  DIAMOND:      'var(--blue-lol)',
+  MASTER:       '#9B59B6',
+  GRANDMASTER:  'var(--loss)',
+  CHALLENGER:   'var(--gold-hover)',
 };
 
 const ROLE_LABELS: Record<string, string> = {
-  TOP: 'Top',
-  JUNGLE: 'Jungle',
-  MID: 'Mid',
-  ADC: 'ADC',
+  TOP:     'Top',
+  JUNGLE:  'Jungle',
+  MID:     'Mid',
+  ADC:     'ADC',
   SUPPORT: 'Suporte',
 };
 
-// Mapeia tier para o nome do emblema no Community Dragon
 const TIER_EMBLEM: Record<string, string> = {
-  IRON: 'iron',
-  BRONZE: 'bronze',
-  SILVER: 'silver',
-  GOLD: 'gold',
-  PLATINUM: 'platinum',
-  EMERALD: 'emerald',
-  DIAMOND: 'diamond',
-  MASTER: 'master',
-  GRANDMASTER: 'grandmaster',
-  CHALLENGER: 'challenger',
+  IRON:         'iron',
+  BRONZE:       'bronze',
+  SILVER:       'silver',
+  GOLD:         'gold',
+  PLATINUM:     'platinum',
+  EMERALD:      'emerald',
+  DIAMOND:      'diamond',
+  MASTER:       'master',
+  GRANDMASTER:  'grandmaster',
+  CHALLENGER:   'challenger',
 };
 
 interface PlayerCardProps {
@@ -52,6 +52,8 @@ interface PlayerCardProps {
   team?: { id: string; name: string; tag: string; logoUrl: string | null } | null;
   DD_VERSION: string;
   linkToProfile?: boolean;
+  // Props explícitas para montar a rota correta /jogadores/[gameName]/[tagLine]
+  gameName?: string | null;
 }
 
 export default function PlayerCard({
@@ -70,10 +72,16 @@ export default function PlayerCard({
   team,
   DD_VERSION,
   linkToProfile = true,
+  gameName,
 }: PlayerCardProps) {
-  const tierColor = TIER_COLORS[tier?.toUpperCase()] ?? 'text-white';
-  const roleLabel = ROLE_LABELS[role?.toUpperCase()] ?? role;
-  const tierKey = TIER_EMBLEM[tier?.toUpperCase()] ?? null;
+  const tierColor   = TIER_COLOR_VAR[tier?.toUpperCase()] ?? 'var(--text)';
+  const roleLabel   = ROLE_LABELS[role?.toUpperCase()] ?? role;
+  const tierKey     = TIER_EMBLEM[tier?.toUpperCase()] ?? null;
+
+  // Rota correta: /jogadores/[gameName]/[tagLine]
+  // Fallback para summonerName caso gameName não seja passado explicitamente
+  const routeName   = gameName ?? summonerName;
+  const profileHref = `/jogadores/${encodeURIComponent(routeName)}/${encodeURIComponent(tagLine)}`;
 
   const profileIconUrl = profileIconId
     ? `https://ddragon.leagueoflegends.com/cdn/${DD_VERSION}/img/profileicon/${profileIconId}.png`
@@ -88,17 +96,30 @@ export default function PlayerCard({
     : null;
 
   const nameEl = (
-    <span className="text-white font-semibold text-base">
+    <span style={{ color: 'var(--text)', fontWeight: 600, fontSize: 'var(--text-base)' }}>
       {summonerName}
-      <span className="text-gray-400 font-normal text-sm"> #{tagLine}</span>
+      <span style={{ color: 'var(--text-muted)', fontWeight: 400, fontSize: 'var(--text-sm)' }}>
+        {' '}#{tagLine}
+      </span>
     </span>
   );
 
   return (
-    <div className="bg-[#0A1628] border border-[#1E3A5F] rounded-xl p-4 flex items-start gap-4">
-
-      {/* Ícone de perfil com moldura */}
-      <div className="flex-shrink-0 relative w-14 h-14">
+    <div
+      style={{
+        background:    'var(--surface)',
+        border:        '1px solid var(--border)',
+        borderRadius:  'var(--radius-lg)',
+        padding:       'var(--sp-4)',
+        display:       'flex',
+        alignItems:    'flex-start',
+        gap:           'var(--sp-4)',
+        transition:    'box-shadow var(--ease-ui), border-color var(--ease-ui)',
+      }}
+      className="hover:border-[var(--border-gold)] hover:shadow-[var(--shadow-md)]"
+    >
+      {/* Ícone de perfil */}
+      <div style={{ flexShrink: 0, position: 'relative', width: 56, height: 56 }}>
         {profileIconUrl ? (
           <>
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -107,10 +128,8 @@ export default function PlayerCard({
               alt={`Ícone de ${summonerName}`}
               width={56}
               height={56}
-              className="rounded-full w-14 h-14 object-cover"
-              onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = 'none';
-              }}
+              style={{ borderRadius: '50%', width: 56, height: 56, objectFit: 'cover' }}
+              onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
             />
             {/* Moldura sobreposta via Community Dragon */}
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -118,36 +137,53 @@ export default function PlayerCard({
               src="https://raw.communitydragon.org/latest/plugins/rcp-fe-lol-static-assets/global/default/images/regalia/regalia-profile-frame-gold.png"
               alt=""
               aria-hidden="true"
-              className="absolute inset-0 w-full h-full pointer-events-none select-none"
-              onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = 'none';
-              }}
+              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+              onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
             />
           </>
         ) : (
-          <div className="w-14 h-14 rounded-full bg-[#1E2A3A] border border-[#1E3A5F] flex items-center justify-center">
-            <span className="text-gray-400 text-sm font-bold">{role?.slice(0, 1) || '?'}</span>
+          <div
+            style={{
+              width: 56, height: 56,
+              borderRadius: '50%',
+              background: 'var(--surface-2)',
+              border: '1px solid var(--border)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}
+          >
+            <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)', fontWeight: 700 }}>
+              {role?.slice(0, 1) || '?'}
+            </span>
           </div>
         )}
       </div>
 
-      <div className="flex-1 min-w-0">
+      <div style={{ flex: 1, minWidth: 0 }}>
         {/* Nome + role */}
-        <div className="flex items-center gap-2 mb-1">
-          {linkToProfile && puuid ? (
-            <Link href={`/jogadores/${puuid}`} className="hover:underline">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', marginBottom: 'var(--sp-1)', flexWrap: 'wrap' }}>
+          {linkToProfile ? (
+            <Link href={profileHref} style={{ textDecoration: 'none' }} className="hover:underline">
               {nameEl}
             </Link>
           ) : (
             nameEl
           )}
-          <span className="text-gray-500 text-xs bg-[#1E2A3A] px-2 py-0.5 rounded">
+          <span
+            style={{
+              color:         'var(--text-faint)',
+              fontSize:      'var(--text-xs)',
+              background:    'var(--surface-2)',
+              border:        '1px solid var(--border-soft)',
+              borderRadius:  'var(--radius-sm)',
+              padding:       '2px 8px',
+            }}
+          >
             {roleLabel}
           </span>
         </div>
 
         {/* Emblema de rank + stats */}
-        <div className="flex items-center gap-3 mb-2">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-3)', marginBottom: 'var(--sp-2)' }}>
           {rankEmblemUrl && (
             // eslint-disable-next-line @next/next/no-img-element
             <img
@@ -155,48 +191,71 @@ export default function PlayerCard({
               alt={`Emblema ${tier}`}
               width={40}
               height={40}
-              className="w-10 h-10 object-contain flex-shrink-0"
-              onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = 'none';
-              }}
+              style={{ width: 40, height: 40, objectFit: 'contain', flexShrink: 0 }}
+              onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
             />
           )}
-          <div className="flex flex-col">
-            <span className={`font-bold text-sm ${tierColor}`}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <span style={{ fontWeight: 700, fontSize: 'var(--text-sm)', color: tierColor }}>
               {tier} {rank}
             </span>
-            <span className="text-gray-500 text-xs">{lp} LP</span>
+            <span style={{ color: 'var(--text-faint)', fontSize: 'var(--text-xs)' }}>
+              {lp} LP
+            </span>
           </div>
-          <span className="text-gray-400 text-xs">{wins}W/{losses}L</span>
-          <span className={`text-xs font-semibold ${wr >= 50 ? 'text-blue-400' : 'text-red-400'}`}>
+          <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>
+            {wins}V/{losses}D
+          </span>
+          <span
+            style={{
+              fontSize:   'var(--text-xs)',
+              fontWeight: 600,
+              color:      wr >= 50 ? 'var(--win)' : 'var(--loss)',
+              background: wr >= 50 ? 'var(--win-dim)' : 'var(--loss-dim)',
+              border:     `1px solid ${wr >= 50 ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.3)'}`,
+              borderRadius: 'var(--radius-full)',
+              padding:    '2px 8px',
+            }}
+          >
             {wr}% WR
           </span>
         </div>
 
         {/* Campeão mais jogado */}
         {championIconUrl && (
-          <div className="flex items-center gap-2 mb-1">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', marginBottom: 'var(--sp-1)' }}>
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={championIconUrl}
               alt={topChampionId ?? 'campeão'}
               width={24}
               height={24}
-              className="w-6 h-6 rounded object-cover border border-[#1E3A5F]"
-              onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = 'none';
+              style={{
+                width: 24, height: 24,
+                borderRadius: 'var(--radius-sm)',
+                objectFit: 'cover',
+                border: '1px solid var(--border)',
               }}
+              onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
             />
-            <span className="text-gray-400 text-xs">{topChampionId}</span>
+            <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>
+              {topChampionId}
+            </span>
           </div>
         )}
 
         {/* Time */}
         {team && (
-          <div className="mt-1">
+          <div style={{ marginTop: 'var(--sp-1)' }}>
             <Link
               href={`/times/${team.tag}`}
-              className="text-xs text-gray-400 hover:text-blue-400"
+              style={{
+                fontSize:       'var(--text-xs)',
+                color:          'var(--text-muted)',
+                textDecoration: 'none',
+                transition:     'color var(--ease-ui)',
+              }}
+              className="hover:text-[var(--blue-lol)]"
             >
               {team.name} [{team.tag}]
             </Link>

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -1,43 +1,115 @@
 'use client';
 import React from 'react';
-import { rankEmblemUrl } from '@/lib/riot';
 
 interface Props {
   summonerName: string;
   tagLine: string;
   profileIconId: number;
   summonerLevel: number;
-  DD_VERSION: string;
+  /** true se o jogador tiver player_id vinculado no ArenaGG (riot_accounts + players) */
+  isLinked?: boolean;
 }
 
-export default function ProfileHeader({ summonerName, tagLine, profileIconId, summonerLevel, DD_VERSION }: Props) {
+export default function ProfileHeader({
+  summonerName,
+  tagLine,
+  profileIconId,
+  summonerLevel,
+  isLinked = false,
+}: Props) {
   return (
     <div className="flex items-end gap-6">
       {/* Avatar com moldura de nível */}
       <div className="relative flex-shrink-0 group">
-        <div className="w-32 h-32 rounded-3xl border-4 border-[#C89B3C] overflow-hidden shadow-2xl shadow-black relative z-10 bg-[#0A0E17]">
+        <div
+          style={{
+            width: 128,
+            height: 128,
+            borderRadius: "var(--radius-xl)",
+            border: "3px solid var(--gold)",
+            overflow: "hidden",
+            boxShadow: "0 0 32px rgba(200, 168, 75, 0.2)",
+            background: "var(--surface)",
+            position: "relative",
+            zIndex: 10,
+          }}
+        >
+          {/* CommunityDragon — padrão do projeto, sem depender de DD_VERSION */}
           <img
-            src={`https://ddragon.leagueoflegends.com/cdn/${DD_VERSION}/img/profileicon/${profileIconId}.png`}
-            alt={summonerName}
+            src={`https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/profile-icons/${profileIconId}.jpg`}
+            alt={`Ícone de perfil de ${summonerName}`}
             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
           />
         </div>
-        <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 bg-[#C89B3C] text-[#0A0E17] text-xs font-black px-4 py-1 rounded-full shadow-xl z-20 border-2 border-[#0A0E17] tracking-tighter">
+        <div
+          style={{
+            position: "absolute",
+            bottom: -12,
+            left: "50%",
+            transform: "translateX(-50%)",
+            background: "var(--gold)",
+            color: "var(--bg)",
+            fontSize: "var(--text-xs)",
+            fontWeight: 900,
+            padding: "2px 12px",
+            borderRadius: "var(--radius-full)",
+            border: "2px solid var(--bg)",
+            whiteSpace: "nowrap",
+            zIndex: 20,
+          }}
+        >
           LVL {summonerLevel}
         </div>
       </div>
 
-      {/* Nome + tag */}
+      {/* Nome + tag + status */}
       <div className="pb-4">
         <div className="flex items-baseline gap-3">
-          <h1 className="text-white font-black text-5xl leading-none tracking-tighter drop-shadow-lg">
+          <h1
+            style={{
+              color: "var(--text)",
+              fontFamily: "var(--font-display)",
+              fontSize: "var(--text-2xl)",
+              fontWeight: 900,
+              lineHeight: 1,
+              letterSpacing: "-0.03em",
+            }}
+          >
             {summonerName}
           </h1>
-          <span className="text-[#718096] font-bold text-2xl tracking-tight opacity-80">#{tagLine}</span>
+          <span
+            style={{
+              color: "var(--text-muted)",
+              fontWeight: 700,
+              fontSize: "var(--text-lg)",
+              opacity: 0.8,
+            }}
+          >
+            #{tagLine}
+          </span>
         </div>
         <div className="flex items-center gap-2 mt-2">
-           <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-           <p className="text-[#A0AEC0] text-sm font-bold uppercase tracking-widest">BR1 · Perfil Verificado</p>
+          <span
+            className="animate-pulse"
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "var(--radius-full)",
+              background: "var(--win)",
+              display: "inline-block",
+            }}
+          />
+          <p
+            style={{
+              color: "var(--text-muted)",
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+            }}
+          >
+            BR1 · {isLinked ? "Vinculado ao ArenaGG" : "Perfil Público"}
+          </p>
         </div>
       </div>
     </div>

--- a/components/profile/RankCard.tsx
+++ b/components/profile/RankCard.tsx
@@ -1,0 +1,105 @@
+import { rankEmblemUrl } from "@/lib/riot";
+
+const TIER_COLORS: Record<string, string> = {
+  IRON: "#8B7A6B",       BRONZE: "#CD7F32",   SILVER: "#A8A9AD",
+  GOLD: "#FFD700",       PLATINUM: "#00E5CC", EMERALD: "#50C878",
+  DIAMOND: "#99CCFF",    MASTER: "#9B59B6",   GRANDMASTER: "#E74C3C",
+  CHALLENGER: "#00D4FF",
+};
+
+interface RankEntry {
+  queueType: string;
+  tier: string;
+  rank: string;
+  leaguePoints: number;
+  wins: number;
+  losses: number;
+  hotStreak: boolean;
+  veteran: boolean;
+}
+
+export function RankCard({ r }: { r: RankEntry }) {
+  const color = TIER_COLORS[r.tier] ?? "#fff";
+  const total = r.wins + r.losses;
+  const wr    = total > 0 ? Math.round((r.wins / total) * 100) : 0;
+
+  return (
+    <div
+      style={{
+        background: `linear-gradient(135deg, ${color}0D 0%, #0A1428 45%)`,
+        border: `1px solid ${color}33`,
+        borderRadius: 16,
+        padding: "20px",
+        display: "flex",
+        alignItems: "center",
+        gap: 16,
+        position: "relative",
+        overflow: "hidden",
+        transition: "box-shadow 200ms ease, transform 200ms ease",
+      }}
+      className="hover:scale-[1.01] hover:shadow-lg"
+    >
+      {/* Brilho de canto */}
+      <div
+        style={{
+          position: "absolute", top: 0, right: 0,
+          width: 120, height: 120,
+          background: `radial-gradient(circle at top right, ${color}14, transparent 70%)`,
+          pointerEvents: "none",
+        }}
+      />
+
+      <img
+        src={rankEmblemUrl(r.tier)}
+        width={80}
+        height={80}
+        alt={r.tier}
+        style={{ width: 80, height: 80, objectFit: "contain", flexShrink: 0 }}
+      />
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ color: "#9CA3AF", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 4 }}>
+          {r.queueType === "RANKED_SOLO_5x5" ? "Solo / Duo" : "Flex 5v5"}
+        </p>
+        <p style={{ fontSize: 22, fontWeight: 800, color, lineHeight: 1.1, marginBottom: 2 }}>
+          {r.tier} <span style={{ fontSize: 18 }}>{r.rank}</span>
+        </p>
+        <p style={{ fontSize: 14, color: "#fff", fontWeight: 600, marginBottom: 6 }}>
+          {r.leaguePoints} LP
+        </p>
+
+        {/* Barra de winrate */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{ flex: 1, height: 5, borderRadius: 9999, background: "#1E3A5F", overflow: "hidden" }}>
+            <div
+              style={{
+                width: `${wr}%`, height: "100%", borderRadius: 9999,
+                background: wr >= 50 ? "#4ADE80" : "#F87171",
+                transition: "width 600ms ease",
+              }}
+            />
+          </div>
+          <span style={{ fontSize: 12, color: wr >= 50 ? "#4ADE80" : "#F87171", fontWeight: 700, minWidth: 38 }}>
+            {wr}%
+          </span>
+        </div>
+        <p style={{ fontSize: 11, color: "#6B7280", marginTop: 4 }}>
+          {r.wins}V · {r.losses}D · {total} jogos
+        </p>
+
+        <div style={{ display: "flex", gap: 4, flexWrap: "wrap", marginTop: 8 }}>
+          {r.hotStreak && (
+            <span style={{ fontSize: 10, background: "rgba(249,115,22,0.15)", color: "#FB923C", border: "1px solid rgba(249,115,22,0.3)", borderRadius: 9999, padding: "2px 7px", fontWeight: 700 }}>
+              🔥 Hot Streak
+            </span>
+          )}
+          {r.veteran && (
+            <span style={{ fontSize: 10, background: "rgba(200,168,75,0.12)", color: "#C8A84B", border: "1px solid rgba(200,168,75,0.3)", borderRadius: 9999, padding: "2px 7px", fontWeight: 700 }}>
+              ⚔️ Veterano
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/profile/RankCard.tsx
+++ b/components/profile/RankCard.tsx
@@ -1,9 +1,19 @@
+"use client";
+import { useRef } from "react";
+import { motion, useMotionValue, useSpring, useTransform, animate } from "framer-motion";
+import { useEffect } from "react";
 import { rankEmblemUrl } from "@/lib/riot";
 
 const TIER_COLORS: Record<string, string> = {
-  IRON: "#8B7A6B",       BRONZE: "#CD7F32",   SILVER: "#A8A9AD",
-  GOLD: "#FFD700",       PLATINUM: "#00E5CC", EMERALD: "#50C878",
-  DIAMOND: "#99CCFF",    MASTER: "#9B59B6",   GRANDMASTER: "#E74C3C",
+  IRON: "#8B7A6B",
+  BRONZE: "#CD7F32",
+  SILVER: "#A8A9AD",
+  GOLD: "#FFD700",
+  PLATINUM: "#00E5CC",
+  EMERALD: "#50C878",
+  DIAMOND: "#99CCFF",
+  MASTER: "#9B59B6",
+  GRANDMASTER: "#E74C3C",
   CHALLENGER: "#00D4FF",
 };
 
@@ -18,88 +28,214 @@ interface RankEntry {
   veteran: boolean;
 }
 
+/** Contador de LP animado com spring */
+function AnimatedLP({ value }: { value: number }) {
+  const motionVal = useMotionValue(0);
+  const spring = useSpring(motionVal, { stiffness: 80, damping: 20 });
+  const display = useTransform(spring, (v) => Math.round(v).toString());
+
+  useEffect(() => {
+    const controls = animate(motionVal, value, { duration: 1.2, ease: "easeOut" });
+    return controls.stop;
+  }, [value, motionVal]);
+
+  return (
+    <motion.span className="font-semibold tabular-nums" style={{ color: "var(--text)", fontSize: "var(--text-sm)" }}>
+      {display}
+    </motion.span>
+  );
+}
+
+/** Barra de winrate com largura animada via framer-motion */
+function WinrateBar({ wr, color }: { wr: number; color: string }) {
+  return (
+    <div className="flex items-center gap-2" style={{ marginTop: "var(--sp-2)" }}>
+      <div
+        style={{
+          flex: 1,
+          height: 5,
+          borderRadius: 9999,
+          background: "rgba(30,58,95,0.6)",
+          overflow: "hidden",
+        }}
+      >
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${wr}%` }}
+          transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1], delay: 0.2 }}
+          style={{
+            height: "100%",
+            borderRadius: 9999,
+            background: wr >= 50 ? "#4ADE80" : "#F87171",
+          }}
+        />
+      </div>
+      <span
+        style={{
+          fontSize: "var(--text-xs)",
+          fontWeight: 700,
+          minWidth: 38,
+          color: wr >= 50 ? "#4ADE80" : "#F87171",
+        }}
+      >
+        {wr}%
+      </span>
+    </div>
+  );
+}
+
 export function RankCard({ r }: { r: RankEntry }) {
   const color = TIER_COLORS[r.tier] ?? "#fff";
   const total = r.wins + r.losses;
-  const wr    = total > 0 ? Math.round((r.wins / total) * 100) : 0;
+  const wr = total > 0 ? Math.round((r.wins / total) * 100) : 0;
+
+  const cardRef = useRef<HTMLDivElement>(null);
+  const mouseX = useMotionValue(0);
+  const mouseY = useMotionValue(0);
+
+  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
+    const rect = cardRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    mouseX.set(e.clientX - rect.left);
+    mouseY.set(e.clientY - rect.top);
+  }
+
+  const spotX = useSpring(mouseX, { stiffness: 150, damping: 20 });
+  const spotY = useSpring(mouseY, { stiffness: 150, damping: 20 });
+  const background = useTransform(
+    [spotX, spotY],
+    ([x, y]: number[]) =>
+      `radial-gradient(200px circle at ${x}px ${y}px, ${color}22, transparent 70%)`
+  );
 
   return (
-    <div
+    <motion.div
+      ref={cardRef}
+      onMouseMove={handleMouseMove}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+      whileHover={{ scale: 1.015, transition: { duration: 0.2 } }}
       style={{
-        background: `linear-gradient(135deg, ${color}0D 0%, #0A1428 45%)`,
+        background: `linear-gradient(135deg, ${color}0D 0%, var(--surface) 45%)`,
         border: `1px solid ${color}33`,
-        borderRadius: 16,
-        padding: "20px",
-        display: "flex",
-        alignItems: "center",
-        gap: 16,
+        borderRadius: "var(--radius-lg)",
+        padding: "var(--sp-5)",
         position: "relative",
         overflow: "hidden",
-        transition: "box-shadow 200ms ease, transform 200ms ease",
+        cursor: "default",
+        boxShadow: `0 4px 20px rgba(0,0,0,0.35)`,
       }}
-      className="hover:scale-[1.01] hover:shadow-lg"
     >
-      {/* Brilho de canto */}
-      <div
+      {/* Spotlight glow — segue cursor */}
+      <motion.div
         style={{
-          position: "absolute", top: 0, right: 0,
-          width: 120, height: 120,
-          background: `radial-gradient(circle at top right, ${color}14, transparent 70%)`,
+          position: "absolute",
+          inset: 0,
+          background,
           pointerEvents: "none",
+          borderRadius: "inherit",
         }}
       />
 
-      <img
-        src={rankEmblemUrl(r.tier)}
-        width={80}
-        height={80}
-        alt={r.tier}
-        style={{ width: 80, height: 80, objectFit: "contain", flexShrink: 0 }}
-      />
-
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <p style={{ color: "#9CA3AF", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 4 }}>
-          {r.queueType === "RANKED_SOLO_5x5" ? "Solo / Duo" : "Flex 5v5"}
-        </p>
-        <p style={{ fontSize: 22, fontWeight: 800, color, lineHeight: 1.1, marginBottom: 2 }}>
-          {r.tier} <span style={{ fontSize: 18 }}>{r.rank}</span>
-        </p>
-        <p style={{ fontSize: 14, color: "#fff", fontWeight: 600, marginBottom: 6 }}>
-          {r.leaguePoints} LP
-        </p>
-
-        {/* Barra de winrate */}
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <div style={{ flex: 1, height: 5, borderRadius: 9999, background: "#1E3A5F", overflow: "hidden" }}>
-            <div
-              style={{
-                width: `${wr}%`, height: "100%", borderRadius: 9999,
-                background: wr >= 50 ? "#4ADE80" : "#F87171",
-                transition: "width 600ms ease",
-              }}
-            />
-          </div>
-          <span style={{ fontSize: 12, color: wr >= 50 ? "#4ADE80" : "#F87171", fontWeight: 700, minWidth: 38 }}>
-            {wr}%
-          </span>
+      {/* Drop-shadow no emblema */}
+      <div className="flex items-center gap-4" style={{ position: "relative", zIndex: 1 }}>
+        <div
+          style={{
+            filter: `drop-shadow(0 0 12px ${color}55) drop-shadow(0 0 4px ${color}33)`,
+            flexShrink: 0,
+          }}
+        >
+          <img
+            src={rankEmblemUrl(r.tier)}
+            width={80}
+            height={80}
+            alt={r.tier}
+            style={{ width: 80, height: 80, objectFit: "contain" }}
+          />
         </div>
-        <p style={{ fontSize: 11, color: "#6B7280", marginTop: 4 }}>
-          {r.wins}V · {r.losses}D · {total} jogos
-        </p>
 
-        <div style={{ display: "flex", gap: 4, flexWrap: "wrap", marginTop: 8 }}>
-          {r.hotStreak && (
-            <span style={{ fontSize: 10, background: "rgba(249,115,22,0.15)", color: "#FB923C", border: "1px solid rgba(249,115,22,0.3)", borderRadius: 9999, padding: "2px 7px", fontWeight: 700 }}>
-              🔥 Hot Streak
-            </span>
-          )}
-          {r.veteran && (
-            <span style={{ fontSize: 10, background: "rgba(200,168,75,0.12)", color: "#C8A84B", border: "1px solid rgba(200,168,75,0.3)", borderRadius: 9999, padding: "2px 7px", fontWeight: 700 }}>
-              ⚔️ Veterano
-            </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* Label fila */}
+          <p
+            style={{
+              color: "var(--text-faint)",
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              marginBottom: "var(--sp-1)",
+            }}
+          >
+            {r.queueType === "RANKED_SOLO_5x5" ? "Solo / Duo" : "Flex 5v5"}
+          </p>
+
+          {/* Tier + Rank */}
+          <p
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: "var(--text-xl)",
+              fontWeight: 800,
+              color,
+              lineHeight: 1.1,
+              marginBottom: "var(--sp-1)",
+            }}
+          >
+            {r.tier}{" "}
+            <span style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}>{r.rank}</span>
+          </p>
+
+          {/* LP animado */}
+          <p style={{ marginBottom: "var(--sp-2)", display: "flex", alignItems: "baseline", gap: 4 }}>
+            <AnimatedLP value={r.leaguePoints} />
+            <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>LP</span>
+          </p>
+
+          {/* Barra winrate animada */}
+          <WinrateBar wr={wr} color={color} />
+
+          {/* Stats */}
+          <p style={{ fontSize: "var(--text-xs)", color: "var(--text-faint)", marginTop: "var(--sp-1)" }}>
+            {r.wins}V · {r.losses}D · {total} jogos
+          </p>
+
+          {/* Badges */}
+          {(r.hotStreak || r.veteran) && (
+            <div className="flex flex-wrap gap-1" style={{ marginTop: "var(--sp-2)" }}>
+              {r.hotStreak && (
+                <span
+                  style={{
+                    fontSize: "var(--text-xs)",
+                    background: "rgba(249,115,22,0.12)",
+                    color: "#FB923C",
+                    border: "1px solid rgba(249,115,22,0.28)",
+                    borderRadius: 9999,
+                    padding: "2px 8px",
+                    fontWeight: 700,
+                  }}
+                >
+                  🔥 Hot Streak
+                </span>
+              )}
+              {r.veteran && (
+                <span
+                  style={{
+                    fontSize: "var(--text-xs)",
+                    background: "var(--gold-dim)",
+                    color: "var(--gold)",
+                    border: "1px solid var(--border-gold)",
+                    borderRadius: 9999,
+                    padding: "2px 8px",
+                    fontWeight: 700,
+                  }}
+                >
+                  ⚔️ Veterano
+                </span>
+              )}
+            </div>
           )}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/components/profile/RankCard.tsx
+++ b/components/profile/RankCard.tsx
@@ -41,7 +41,10 @@ function AnimatedLP({ value }: { value: number }) {
   }, [value, motionVal]);
 
   return (
-    <motion.span className="font-semibold tabular-nums" style={{ color: "var(--text)", fontSize: "var(--text-sm)" }}>
+    <motion.span
+      className="font-semibold tabular-nums"
+      style={{ color: "var(--text)", fontSize: "var(--text-sm)" }}
+    >
       {display}
     </motion.span>
   );
@@ -56,7 +59,7 @@ function WinrateBar({ wr }: { wr: number }) {
           flex: 1,
           height: 5,
           borderRadius: "var(--radius-full)",
-          background: "rgba(30,58,95,0.6)",
+          background: "var(--border)",
           overflow: "hidden",
         }}
       >
@@ -86,7 +89,7 @@ function WinrateBar({ wr }: { wr: number }) {
 }
 
 export function RankCard({ r }: { r: RankEntry }) {
-  const color = TIER_COLORS[r.tier] ?? "#fff";
+  const color = TIER_COLORS[r.tier] ?? "var(--text)";
   const total = r.wins + r.losses;
   const wr = total > 0 ? Math.round((r.wins / total) * 100) : 0;
 
@@ -188,7 +191,14 @@ export function RankCard({ r }: { r: RankEntry }) {
           </p>
 
           {/* LP animado */}
-          <p style={{ marginBottom: "var(--sp-2)", display: "flex", alignItems: "baseline", gap: 4 }}>
+          <p
+            style={{
+              marginBottom: "var(--sp-2)",
+              display: "flex",
+              alignItems: "baseline",
+              gap: 4,
+            }}
+          >
             <AnimatedLP value={r.leaguePoints} />
             <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>LP</span>
           </p>
@@ -197,11 +207,17 @@ export function RankCard({ r }: { r: RankEntry }) {
           <WinrateBar wr={wr} />
 
           {/* Stats */}
-          <p style={{ fontSize: "var(--text-xs)", color: "var(--text-faint)", marginTop: "var(--sp-1)" }}>
+          <p
+            style={{
+              fontSize: "var(--text-xs)",
+              color: "var(--text-faint)",
+              marginTop: "var(--sp-1)",
+            }}
+          >
             {r.wins}V · {r.losses}D · {total} jogos
           </p>
 
-          {/* Badges — sem emoji */}
+          {/* Badges Hot Streak / Veterano */}
           {(r.hotStreak || r.veteran) && (
             <div className="flex flex-wrap gap-1" style={{ marginTop: "var(--sp-2)" }}>
               {r.hotStreak && (

--- a/components/profile/RankCard.tsx
+++ b/components/profile/RankCard.tsx
@@ -2,6 +2,7 @@
 import { useRef } from "react";
 import { motion, useMotionValue, useSpring, useTransform, animate } from "framer-motion";
 import { useEffect } from "react";
+import { Flame, Sword } from "lucide-react";
 import { rankEmblemUrl } from "@/lib/riot";
 
 const TIER_COLORS: Record<string, string> = {
@@ -47,14 +48,14 @@ function AnimatedLP({ value }: { value: number }) {
 }
 
 /** Barra de winrate com largura animada via framer-motion */
-function WinrateBar({ wr, color }: { wr: number; color: string }) {
+function WinrateBar({ wr }: { wr: number }) {
   return (
     <div className="flex items-center gap-2" style={{ marginTop: "var(--sp-2)" }}>
       <div
         style={{
           flex: 1,
           height: 5,
-          borderRadius: 9999,
+          borderRadius: "var(--radius-full)",
           background: "rgba(30,58,95,0.6)",
           overflow: "hidden",
         }}
@@ -65,8 +66,8 @@ function WinrateBar({ wr, color }: { wr: number; color: string }) {
           transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1], delay: 0.2 }}
           style={{
             height: "100%",
-            borderRadius: 9999,
-            background: wr >= 50 ? "#4ADE80" : "#F87171",
+            borderRadius: "var(--radius-full)",
+            background: wr >= 50 ? "var(--win)" : "var(--loss)",
           }}
         />
       </div>
@@ -75,7 +76,7 @@ function WinrateBar({ wr, color }: { wr: number; color: string }) {
           fontSize: "var(--text-xs)",
           fontWeight: 700,
           minWidth: 38,
-          color: wr >= 50 ? "#4ADE80" : "#F87171",
+          color: wr >= 50 ? "var(--win)" : "var(--loss)",
         }}
       >
         {wr}%
@@ -124,7 +125,7 @@ export function RankCard({ r }: { r: RankEntry }) {
         position: "relative",
         overflow: "hidden",
         cursor: "default",
-        boxShadow: `0 4px 20px rgba(0,0,0,0.35)`,
+        boxShadow: "var(--shadow-card)",
       }}
     >
       {/* Spotlight glow — segue cursor */}
@@ -151,6 +152,7 @@ export function RankCard({ r }: { r: RankEntry }) {
             width={80}
             height={80}
             alt={r.tier}
+            loading="lazy"
             style={{ width: 80, height: 80, objectFit: "contain" }}
           />
         </div>
@@ -192,44 +194,52 @@ export function RankCard({ r }: { r: RankEntry }) {
           </p>
 
           {/* Barra winrate animada */}
-          <WinrateBar wr={wr} color={color} />
+          <WinrateBar wr={wr} />
 
           {/* Stats */}
           <p style={{ fontSize: "var(--text-xs)", color: "var(--text-faint)", marginTop: "var(--sp-1)" }}>
             {r.wins}V · {r.losses}D · {total} jogos
           </p>
 
-          {/* Badges */}
+          {/* Badges — sem emoji */}
           {(r.hotStreak || r.veteran) && (
             <div className="flex flex-wrap gap-1" style={{ marginTop: "var(--sp-2)" }}>
               {r.hotStreak && (
                 <span
                   style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
                     fontSize: "var(--text-xs)",
                     background: "rgba(249,115,22,0.12)",
                     color: "#FB923C",
                     border: "1px solid rgba(249,115,22,0.28)",
-                    borderRadius: 9999,
+                    borderRadius: "var(--radius-full)",
                     padding: "2px 8px",
                     fontWeight: 700,
                   }}
                 >
-                  🔥 Hot Streak
+                  <Flame size={11} aria-hidden="true" />
+                  Hot Streak
                 </span>
               )}
               {r.veteran && (
                 <span
                   style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
                     fontSize: "var(--text-xs)",
                     background: "var(--gold-dim)",
                     color: "var(--gold)",
                     border: "1px solid var(--border-gold)",
-                    borderRadius: 9999,
+                    borderRadius: "var(--radius-full)",
                     padding: "2px 8px",
                     fontWeight: 700,
                   }}
                 >
-                  ⚔️ Veterano
+                  <Sword size={11} aria-hidden="true" />
+                  Veterano
                 </span>
               )}
             </div>

--- a/components/ui/background-beams.tsx
+++ b/components/ui/background-beams.tsx
@@ -1,0 +1,93 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export const BackgroundBeams = React.memo(
+  ({ className }: { className?: string }) => {
+    const paths = [
+      "M-380 -189C-380 -189 -312 216 152 343C616 470 684 875 684 875",
+      "M-373 -197C-373 -197 -305 208 159 335C623 462 691 867 691 867",
+      "M-366 -205C-366 -205 -298 200 166 327C630 454 698 859 698 859",
+      "M-359 -213C-359 -213 -291 192 173 319C637 446 705 851 705 851",
+      "M-352 -221C-352 -221 -284 184 180 311C644 438 712 843 712 843",
+      "M-345 -229C-345 -229 -277 176 187 303C651 430 719 835 719 835",
+      "M-338 -237C-338 -237 -270 168 194 295C658 422 726 827 726 827",
+      "M-331 -245C-331 -245 -263 160 201 287C665 414 733 819 733 819",
+      "M-324 -253C-324 -253 -256 152 208 279C672 406 740 811 740 811",
+      "M-317 -261C-317 -261 -249 144 215 271C679 398 747 803 747 803",
+      "M-310 -269C-310 -269 -242 136 222 263C686 390 754 795 754 795",
+      "M-303 -277C-303 -277 -235 128 229 255C693 382 761 787 761 787",
+      "M-296 -285C-296 -285 -228 120 236 247C700 374 768 779 768 779",
+      "M-289 -293C-289 -293 -221 112 243 239C707 366 775 771 775 771",
+      "M-282 -301C-282 -301 -214 104 250 231C714 358 782 763 782 763",
+      "M-275 -309C-275 -309 -207 96 257 223C721 350 789 755 789 755",
+      "M-268 -317C-268 -317 -200 88 264 215C728 342 796 747 796 747",
+      "M-261 -325C-261 -325 -193 80 271 207C735 334 803 739 803 739",
+      "M-254 -333C-254 -333 -186 72 278 199C742 326 810 731 810 731",
+      "M-247 -341C-247 -341 -179 64 285 191C749 318 817 723 817 723",
+    ];
+
+    return (
+      <div
+        className={cn(
+          "absolute inset-0 flex items-center justify-center overflow-hidden [mask-image:radial-gradient(ellipse_at_center,white,transparent)]",
+          className
+        )}
+      >
+        <svg
+          className="absolute z-0 flex h-full w-full"
+          width="100%"
+          height="100%"
+          viewBox="0 0 696 316"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M-380 -189C-380 -189 -312 216 152 343C616 470 684 875 684 875"
+            stroke="url(#linearGradient-1)"
+            strokeOpacity="0.3"
+            strokeWidth="0.5"
+          />
+          {paths.map((path, index) => (
+            <path
+              key={`path-` + index}
+              d={path}
+              stroke={`url(#linearGradient-${index + 1})`}
+              strokeOpacity="0.4"
+              strokeWidth="0.5"
+            />
+          ))}
+          <defs>
+            {paths.map((path, index) => (
+              <linearGradient
+                id={`linearGradient-${index + 1}`}
+                key={`gradient-${index}`}
+                x1="0%"
+                y1="0%"
+                x2="100%"
+                y2="100%"
+              >
+                <stop stopColor="#C8A84B" stopOpacity="0" />
+                <stop offset="32.5%" stopColor="#C8A84B" />
+                <stop offset="100%" stopColor="#C8A84B" stopOpacity="0" />
+              </linearGradient>
+            ))}
+            <radialGradient
+              id="paint0_radial"
+              cx="0"
+              cy="0"
+              r="1"
+              gradientUnits="userSpaceOnUse"
+              gradientTransform="translate(352 34) rotate(90) scale(555 1560.62)"
+            >
+              <stop offset="0.0666667" stopColor="#C8A84B" />
+              <stop offset="0.243243" stopColor="#C8A84B" stopOpacity="0" />
+            </radialGradient>
+          </defs>
+        </svg>
+      </div>
+    );
+  }
+);
+
+BackgroundBeams.displayName = "BackgroundBeams";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,200 @@
+"use client";
+import { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import Link, { LinkProps } from "next/link";
+import { cn } from "@/lib/utils";
+
+/* ─────────────────────────────────────────────────────────────────────────
+   StatefulButton — PR5
+   Estados: idle | loading | success | error
+   Variantes: primary | outline | ghost
+   Uso:
+     <StatefulButton variant="primary" onClickAsync={handleSubmit}>
+       Criar Torneio
+     </StatefulButton>
+───────────────────────────────────────────────────────────────────────── */
+
+export type ButtonState = "idle" | "loading" | "success" | "error";
+export type ButtonVariant = "primary" | "outline" | "ghost";
+
+interface StatefulButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  state?: ButtonState;                // controlado externamente (opcional)
+  onClickAsync?: () => Promise<void>; // modo autogerenciado
+  resetDelay?: number;                // ms para voltar ao idle após success/error
+  successLabel?: string;
+  errorLabel?: string;
+  loadingLabel?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const variantClass: Record<ButtonVariant, string> = {
+  primary: "btn-gold",
+  outline: "btn-outline-gold",
+  ghost:
+    "inline-flex items-center justify-center gap-2 px-6 py-2.5 rounded-[var(--radius-md)] text-[var(--text-muted)] font-semibold text-[length:var(--text-sm)] border border-transparent hover:border-[var(--border)] hover:text-[var(--text)] transition-colors",
+};
+
+const sizeClass: Record<string, string> = {
+  sm: "!px-4 !py-1.5 !text-[length:var(--text-xs)]",
+  md: "",
+  lg: "!px-8 !py-3 !text-[length:var(--text-base)]",
+};
+
+// Spinner SVG animado
+function Spinner() {
+  return (
+    <svg
+      className="animate-spin"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
+      <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// Ícone de check
+function CheckIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+// Ícone de erro
+function XIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+export function StatefulButton({
+  variant = "primary",
+  state: externalState,
+  onClickAsync,
+  resetDelay = 2500,
+  successLabel = "Feito!",
+  errorLabel = "Erro — tente novamente",
+  loadingLabel = "Aguarde...",
+  size = "md",
+  children,
+  onClick,
+  disabled,
+  className,
+  ...rest
+}: StatefulButtonProps) {
+  const [internalState, setInternalState] = useState<ButtonState>("idle");
+  const activeState = externalState ?? internalState;
+
+  const handleClick = useCallback(
+    async (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (activeState !== "idle") return;
+
+      // modo manual: delega para onClick pai
+      if (onClick && !onClickAsync) {
+        onClick(e);
+        return;
+      }
+
+      // modo autogerenciado via onClickAsync
+      if (onClickAsync) {
+        setInternalState("loading");
+        try {
+          await onClickAsync();
+          setInternalState("success");
+        } catch {
+          setInternalState("error");
+        } finally {
+          setTimeout(() => setInternalState("idle"), resetDelay);
+        }
+      }
+    },
+    [activeState, onClick, onClickAsync, resetDelay]
+  );
+
+  const isLoading = activeState === "loading";
+  const isSuccess = activeState === "success";
+  const isError   = activeState === "error";
+  const isDisabled = disabled || isLoading || isSuccess;
+
+  // Label e ícone conforme estado
+  const content = (() => {
+    if (isLoading) return <><Spinner />{loadingLabel}</>;
+    if (isSuccess) return <><CheckIcon />{successLabel}</>;
+    if (isError)   return <><XIcon />{errorLabel}</>;
+    return children;
+  })();
+
+  return (
+    <motion.button
+      {...(rest as React.ComponentProps<typeof motion.button>)}
+      className={cn(
+        variantClass[variant],
+        sizeClass[size],
+        isError && "!bg-[var(--loss)] !border-[var(--loss)] !text-white",
+        isSuccess && variant === "primary" && "!bg-[var(--win)] !text-white",
+        isDisabled && "opacity-60 cursor-not-allowed pointer-events-none",
+        className
+      )}
+      onClick={handleClick}
+      disabled={isDisabled}
+      whileTap={!isDisabled ? { scale: 0.97 } : {}}
+      animate={{ scale: 1 }}
+      aria-busy={isLoading}
+      aria-live="polite"
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.span
+          key={activeState}
+          className="inline-flex items-center gap-2"
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -6 }}
+          transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+        >
+          {content}
+        </motion.span>
+      </AnimatePresence>
+    </motion.button>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   ButtonLink — mesmo visual que StatefulButton mas renderiza <Link>
+   Uso:
+     <ButtonLink href="/torneios" variant="outline">Ver Torneios</ButtonLink>
+───────────────────────────────────────────────────────────────────────── */
+interface ButtonLinkProps extends LinkProps {
+  variant?: ButtonVariant;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function ButtonLink({
+  variant = "primary",
+  size = "md",
+  className,
+  children,
+  ...rest
+}: ButtonLinkProps) {
+  return (
+    <Link
+      {...rest}
+      className={cn(variantClass[variant], sizeClass[size], className)}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/ui/card-spotlight.tsx
+++ b/components/ui/card-spotlight.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useMotionValue, useMotionTemplate, motion } from "framer-motion";
+import React, { MouseEvent as ReactMouseEvent, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type SpotlightProps = {
+  radius?: number;
+  color?: string;
+  children: React.ReactNode;
+  className?: string;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export const CardSpotlight = ({
+  children,
+  radius = 350,
+  color = "rgba(200,168,75,0.12)",
+  className,
+  ...props
+}: SpotlightProps) => {
+  const mouseX = useMotionValue(0);
+  const mouseY = useMotionValue(0);
+
+  function handleMouseMove({
+    currentTarget,
+    clientX,
+    clientY,
+  }: ReactMouseEvent<HTMLDivElement>) {
+    const { left, top } = currentTarget.getBoundingClientRect();
+    mouseX.set(clientX - left);
+    mouseY.set(clientY - top);
+  }
+
+  const [isHovering, setIsHovering] = useState(false);
+  const handleMouseEnter = () => setIsHovering(true);
+  const handleMouseLeave = () => setIsHovering(false);
+
+  return (
+    <div
+      className={cn(
+        "group/spotlight relative rounded-2xl border p-6 overflow-hidden",
+        "bg-[#0A1428] border-[rgba(30,58,95,0.9)]",
+        className
+      )}
+      onMouseMove={handleMouseMove}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.div
+        className="pointer-events-none absolute -inset-px rounded-2xl opacity-0 transition duration-300 group-hover/spotlight:opacity-100"
+        style={{
+          background: useMotionTemplate`
+            radial-gradient(
+              ${radius}px circle at ${mouseX}px ${mouseY}px,
+              ${color},
+              transparent 80%
+            )
+          `,
+        }}
+      />
+      {children}
+    </div>
+  );
+};

--- a/components/ui/magnetic-button.tsx
+++ b/components/ui/magnetic-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useRef } from "react";
+import { motion, useMotionValue, useSpring } from "framer-motion";
+
+/* ─────────────────────────────────────────────────────────────────────────
+   MagneticButton — PR6
+   Wrapper que faz qualquer filho "atrair" o cursor.
+
+   Props:
+     strength  — intensidade do efeito (0 = sem movimento, 1 = move 50% do tamanho)
+     children  — qualquer elemento React
+
+   Uso:
+     <MagneticButton strength={0.35}>
+       <Link href="/torneios" className="btn-gold">Ver Torneios</Link>
+     </MagneticButton>
+───────────────────────────────────────────────────────────────────────── */
+
+interface MagneticButtonProps {
+  children: React.ReactNode;
+  strength?: number;
+  className?: string;
+}
+
+const springConfig = { stiffness: 180, damping: 18, mass: 0.5 };
+
+export function MagneticButton({
+  children,
+  strength = 0.35,
+  className,
+}: MagneticButtonProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const rawX = useMotionValue(0);
+  const rawY = useMotionValue(0);
+  const x = useSpring(rawX, springConfig);
+  const y = useSpring(rawY, springConfig);
+
+  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top  + rect.height / 2;
+    rawX.set((e.clientX - centerX) * strength);
+    rawY.set((e.clientY - centerY) * strength);
+  }
+
+  function handleMouseLeave() {
+    rawX.set(0);
+    rawY.set(0);
+  }
+
+  return (
+    <motion.div
+      ref={ref}
+      style={{ x, y, display: "inline-flex" }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/ui/meteors.tsx
+++ b/components/ui/meteors.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { cn } from "@/lib/utils";
+
+export const Meteors = ({
+  number,
+  className,
+}: {
+  number?: number;
+  className?: string;
+}) => {
+  const meteors = new Array(number || 20).fill(true);
+  return (
+    <>
+      {meteors.map((_, idx) => (
+        <span
+          key={"meteor" + idx}
+          className={cn(
+            "animate-meteor-effect absolute top-1/2 left-1/2 h-0.5 w-0.5 rounded-[9999px] bg-[#C8A84B] shadow-[0_0_0_1px_rgba(200,168,75,0.1)] rotate-[215deg]",
+            "before:content-[''] before:absolute before:top-1/2 before:-translate-y-1/2 before:w-[50px] before:h-[1px] before:transform before:-translate-x-[50px] before:bg-gradient-to-r before:from-transparent before:to-[#C8A84B]",
+            className
+          )}
+          style={{
+            top: `${Math.floor(Math.random() * 100)}%`,
+            left: `${Math.floor(Math.random() * 100)}%`,
+            animationDelay: `${Math.random() * 2 + 0.2}s`,
+            animationDuration: `${Math.floor(Math.random() * 8) + 2}s`,
+          }}
+        />
+      ))}
+    </>
+  );
+};

--- a/components/ui/shooting-stars.tsx
+++ b/components/ui/shooting-stars.tsx
@@ -1,0 +1,139 @@
+"use client";
+import { useEffect, useRef, useCallback } from "react";
+
+interface Star {
+  x: number;
+  y: number;
+  len: number;
+  speed: number;
+  size: number;
+  opacity: number;
+  trail: number;
+}
+
+interface ShootingStarsProps {
+  minSpeed?: number;
+  maxSpeed?: number;
+  minDelay?: number;
+  maxDelay?: number;
+  starColor?: string;
+  trailColor?: string;
+  starWidth?: number;
+  starHeight?: number;
+  className?: string;
+}
+
+export function ShootingStars({
+  minSpeed = 8,
+  maxSpeed = 22,
+  minDelay = 900,
+  maxDelay = 3200,
+  starColor = "#C8A84B",
+  trailColor = "rgba(200,168,75,0.12)",
+  starWidth = 2,
+  starHeight = 1,
+  className = "",
+}: ShootingStarsProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const starsRef = useRef<Star[]>([]);
+  const frameRef = useRef<number>(0);
+  const prefersReducedMotion =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
+
+  const spawnStar = useCallback(
+    (canvas: HTMLCanvasElement): Star => ({
+      x: Math.random() * canvas.width * 0.6,
+      y: Math.random() * canvas.height * 0.4,
+      len: Math.random() * 80 + 60,
+      speed: Math.random() * (maxSpeed - minSpeed) + minSpeed,
+      size: starWidth,
+      opacity: Math.random() * 0.6 + 0.4,
+      trail: starHeight,
+    }),
+    [minSpeed, maxSpeed, starWidth, starHeight]
+  );
+
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    // Spawna estrelas em delay aleatório
+    let timeouts: ReturnType<typeof setTimeout>[] = [];
+    const scheduleSpawn = () => {
+      const delay = Math.random() * (maxDelay - minDelay) + minDelay;
+      const t = setTimeout(() => {
+        starsRef.current.push(spawnStar(canvas));
+        scheduleSpawn();
+      }, delay);
+      timeouts.push(t);
+    };
+    // Seed inicial com 2 estrelas
+    starsRef.current = [spawnStar(canvas), spawnStar(canvas)];
+    scheduleSpawn();
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      starsRef.current = starsRef.current.filter((star) => {
+        star.x += star.speed * 0.7;
+        star.y += star.speed * 0.5;
+
+        if (star.x > canvas.width || star.y > canvas.height) return false;
+
+        // Trilha
+        ctx.beginPath();
+        ctx.strokeStyle = trailColor;
+        ctx.lineWidth = star.trail;
+        ctx.moveTo(star.x - star.len * 0.7, star.y - star.len * 0.5);
+        ctx.lineTo(star.x, star.y);
+        ctx.stroke();
+
+        // Ponta brilhante
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+        ctx.fillStyle = starColor;
+        ctx.globalAlpha = star.opacity;
+        ctx.fill();
+        ctx.globalAlpha = 1;
+
+        return true;
+      });
+      frameRef.current = requestAnimationFrame(draw);
+    };
+    frameRef.current = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(frameRef.current);
+      timeouts.forEach(clearTimeout);
+      window.removeEventListener("resize", resize);
+    };
+  }, [prefersReducedMotion, minDelay, maxDelay, starColor, trailColor, spawnStar]);
+
+  if (prefersReducedMotion) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/components/ui/text-flip-board.tsx
+++ b/components/ui/text-flip-board.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface FlipBoardProps {
+  value: number;
+  prefix?: string;
+  suffix?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** Dígito individual com animação de flip vertical */
+function Digit({ digit, style }: { digit: string; style?: React.CSSProperties }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        overflow: "hidden",
+        position: "relative",
+        verticalAlign: "bottom",
+        ...style,
+      }}
+    >
+      <AnimatePresence mode="popLayout" initial={false}>
+        <motion.span
+          key={digit}
+          initial={{ y: "100%", opacity: 0 }}
+          animate={{ y: "0%", opacity: 1 }}
+          exit={{ y: "-100%", opacity: 0 }}
+          transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+          style={{ display: "block" }}
+        >
+          {digit}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  );
+}
+
+/** Counter animado que incrementa de 0 até value ao montar */
+export function FlipBoard({ value, prefix, suffix, className, style }: FlipBoardProps) {
+  const [displayed, setDisplayed] = useState(0);
+  const rafRef = useRef<number>(0);
+  const startRef = useRef<number | null>(null);
+  const duration = 1200; // ms
+
+  useEffect(() => {
+    const from = 0;
+    const to = value;
+
+    const step = (timestamp: number) => {
+      if (!startRef.current) startRef.current = timestamp;
+      const progress = Math.min((timestamp - startRef.current) / duration, 1);
+      // easeOutExpo
+      const eased = progress === 1 ? 1 : 1 - Math.pow(2, -10 * progress);
+      setDisplayed(Math.round(from + (to - from) * eased));
+      if (progress < 1) rafRef.current = requestAnimationFrame(step);
+    };
+
+    rafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [value]);
+
+  // Formata número separando milhar
+  const formatted = displayed.toLocaleString("pt-BR");
+  // Divide em caracteres individuais preservando separadores
+  const chars = formatted.split("");
+
+  return (
+    <span className={className} style={{ display: "inline-flex", alignItems: "baseline", ...style }}>
+      {prefix && (
+        <span style={{ marginRight: 2 }}>{prefix}</span>
+      )}
+      {chars.map((char, i) =>
+        /[0-9]/.test(char) ? (
+          <Digit key={i} digit={char} style={style} />
+        ) : (
+          <span key={i} style={{ display: "inline-block" }}>{char}</span>
+        )
+      )}
+      {suffix && (
+        <span style={{ marginLeft: 2 }}>{suffix}</span>
+      )}
+    </span>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "framer-motion": "^11.3.0",
     "lucide-react": "^0.511.0",
     "next": "^16.2.6",
     "postcss": "^8",

--- a/tailwind.config.d.ts
+++ b/tailwind.config.d.ts
@@ -1,0 +1,4 @@
+declare module "tailwindcss/lib/util/flattenColorPalette" {
+  const flattenColorPalette: (colors: Record<string, unknown>) => Record<string, string>;
+  export default flattenColorPalette;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,9 @@
 import type { Config } from "tailwindcss";
+import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 
 // Plugin do Aceternity UI: expõe cada cor Tailwind como variável CSS
-// ex: var(--sky-500), var(--neutral-800) — necessário para BackgroundBeams e outros
+// ex: var(--sky-500), var(--neutral-800)
 function addVariablesForColors({ addBase, theme }: any) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const flattenColorPalette = require("tailwindcss/lib/util/flattenColorPalette").default;
   const allColors = flattenColorPalette(theme("colors"));
   const newVars = Object.fromEntries(
     Object.entries(allColors).map(([key, val]) => [`--${key}`, val])
@@ -69,13 +68,12 @@ const config: Config = {
         body:    ["Inter", "sans-serif"],
       },
       animation: {
-        shimmer:           "shimmer 1.5s ease-in-out infinite",
-        float:             "float 3s ease-in-out infinite",
-        // Aceternity
-        "background-shine": "background-shine 2s linear infinite",
-        meteor:            "meteor 5s linear infinite",
-        spotlight:         "spotlight 2s ease .75s 1 forwards",
-        scroll:            "scroll var(--animation-duration, 40s) var(--animation-direction, forwards) linear infinite",
+        shimmer:             "shimmer 1.5s ease-in-out infinite",
+        float:               "float 3s ease-in-out infinite",
+        "background-shine":  "background-shine 2s linear infinite",
+        meteor:              "meteor 5s linear infinite",
+        spotlight:           "spotlight 2s ease .75s 1 forwards",
+        scroll:              "scroll var(--animation-duration, 40s) var(--animation-direction, forwards) linear infinite",
       },
       keyframes: {
         shimmer: {
@@ -86,7 +84,6 @@ const config: Config = {
           "0%, 100%": { transform: "translateY(0px)" },
           "50%":      { transform: "translateY(-6px)" },
         },
-        // Aceternity keyframes
         "background-shine": {
           from: { backgroundPosition: "0 0" },
           to:   { backgroundPosition: "-200% 0" },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,17 @@
 import type { Config } from "tailwindcss";
 
+// Plugin do Aceternity UI: expõe cada cor Tailwind como variável CSS
+// ex: var(--sky-500), var(--neutral-800) — necessário para BackgroundBeams e outros
+function addVariablesForColors({ addBase, theme }: any) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const flattenColorPalette = require("tailwindcss/lib/util/flattenColorPalette").default;
+  const allColors = flattenColorPalette(theme("colors"));
+  const newVars = Object.fromEntries(
+    Object.entries(allColors).map(([key, val]) => [`--${key}`, val])
+  );
+  addBase({ ":root": newVars });
+}
+
 const config: Config = {
   darkMode: ["class"],
   content: [
@@ -22,7 +34,6 @@ const config: Config = {
           card:   "#112240",
           border: "#1E3A5F",
         },
-        /* ── Tremor custom theme (paleta ArenaGG) ────────────────── */
         tremor: {
           brand: {
             faint:    "#050D1A",
@@ -58,8 +69,13 @@ const config: Config = {
         body:    ["Inter", "sans-serif"],
       },
       animation: {
-        shimmer: "shimmer 1.5s ease-in-out infinite",
-        float:   "float 3s ease-in-out infinite",
+        shimmer:           "shimmer 1.5s ease-in-out infinite",
+        float:             "float 3s ease-in-out infinite",
+        // Aceternity
+        "background-shine": "background-shine 2s linear infinite",
+        meteor:            "meteor 5s linear infinite",
+        spotlight:         "spotlight 2s ease .75s 1 forwards",
+        scroll:            "scroll var(--animation-duration, 40s) var(--animation-direction, forwards) linear infinite",
       },
       keyframes: {
         shimmer: {
@@ -70,10 +86,27 @@ const config: Config = {
           "0%, 100%": { transform: "translateY(0px)" },
           "50%":      { transform: "translateY(-6px)" },
         },
+        // Aceternity keyframes
+        "background-shine": {
+          from: { backgroundPosition: "0 0" },
+          to:   { backgroundPosition: "-200% 0" },
+        },
+        meteor: {
+          "0%":   { transform: "rotate(215deg) translateX(0)", opacity: "1" },
+          "70%":  { opacity: "1" },
+          "100%": { transform: "rotate(215deg) translateX(-500px)", opacity: "0" },
+        },
+        spotlight: {
+          "0%":   { opacity: "0", transform: "translate(-72%, -62%) scale(0.5)" },
+          "100%": { opacity: "1", transform: "translate(-50%,-40%) scale(1)" },
+        },
+        scroll: {
+          to: { transform: "translate(calc(-50% - 0.5rem))" },
+        },
       },
     },
   },
-  plugins: [],
+  plugins: [addVariablesForColors],
 };
 
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,11 @@
 import type { Config } from "tailwindcss";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — sem types oficiais para esse caminho interno do Tailwind
 import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 
-// Plugin do Aceternity UI: expõe cada cor Tailwind como variável CSS
-// ex: var(--sky-500), var(--neutral-800)
-function addVariablesForColors({ addBase, theme }: any) {
-  const allColors = flattenColorPalette(theme("colors"));
+/** Expõe cada cor Tailwind como variável CSS: var(--sky-500), var(--neutral-800) */
+function addVariablesForColors({ addBase, theme }: { addBase: (vars: Record<string, Record<string, string>>) => void; theme: (path: string) => Record<string, unknown> }) {
+  const allColors = flattenColorPalette(theme("colors")) as Record<string, string>;
   const newVars = Object.fromEntries(
     Object.entries(allColors).map(([key, val]) => [`--${key}`, val])
   );
@@ -33,47 +34,18 @@ const config: Config = {
           card:   "#112240",
           border: "#1E3A5F",
         },
-        tremor: {
-          brand: {
-            faint:    "#050D1A",
-            muted:    "#112240",
-            subtle:   "rgba(200,168,75,0.15)",
-            DEFAULT:  "#C8A84B",
-            emphasis: "#E8D48B",
-            inverted: "#050D1A",
-          },
-          background: {
-            muted:    "#0A1428",
-            subtle:   "#112240",
-            DEFAULT:  "#0D1B2E",
-            emphasis: "#1E3A5F",
-          },
-          border: {
-            DEFAULT: "rgba(30,58,95,0.9)",
-          },
-          ring: {
-            DEFAULT: "#C8A84B",
-          },
-          content: {
-            subtle:   "#4B5563",
-            DEFAULT:  "#94A3B8",
-            emphasis: "#F1F5F9",
-            strong:   "#FFFFFF",
-            inverted: "#050D1A",
-          },
-        },
       },
       fontFamily: {
         display: ["Sora", "Inter", "sans-serif"],
         body:    ["Inter", "sans-serif"],
       },
       animation: {
-        shimmer:             "shimmer 1.5s ease-in-out infinite",
-        float:               "float 3s ease-in-out infinite",
-        "background-shine":  "background-shine 2s linear infinite",
-        meteor:              "meteor 5s linear infinite",
-        spotlight:           "spotlight 2s ease .75s 1 forwards",
-        scroll:              "scroll var(--animation-duration, 40s) var(--animation-direction, forwards) linear infinite",
+        shimmer:            "shimmer 1.5s ease-in-out infinite",
+        float:              "float 3s ease-in-out infinite",
+        "background-shine": "background-shine 2s linear infinite",
+        meteor:             "meteor 5s linear infinite",
+        spotlight:          "spotlight 2s ease .75s 1 forwards",
+        scroll:             "scroll var(--animation-duration, 40s) var(--animation-direction, forwards) linear infinite",
       },
       keyframes: {
         shimmer: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+
 const config: Config = {
   darkMode: ["class"],
   content: [
@@ -9,11 +10,70 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        gold: { DEFAULT: "#C8A84B", light: "#E8D48B", dark: "#8B6914" },
-        lol:  { blue: "#0BC4E3", dark: "#0A1428", darker: "#050D1A", card: "#112240", border: "#1E3A5F" },
+        gold: {
+          DEFAULT: "#C8A84B",
+          light:   "#E8D48B",
+          dark:    "#8B6914",
+        },
+        lol: {
+          blue:   "#0BC4E3",
+          dark:   "#0A1428",
+          darker: "#050D1A",
+          card:   "#112240",
+          border: "#1E3A5F",
+        },
+        /* ── Tremor custom theme (paleta ArenaGG) ────────────────── */
+        tremor: {
+          brand: {
+            faint:    "#050D1A",
+            muted:    "#112240",
+            subtle:   "rgba(200,168,75,0.15)",
+            DEFAULT:  "#C8A84B",
+            emphasis: "#E8D48B",
+            inverted: "#050D1A",
+          },
+          background: {
+            muted:    "#0A1428",
+            subtle:   "#112240",
+            DEFAULT:  "#0D1B2E",
+            emphasis: "#1E3A5F",
+          },
+          border: {
+            DEFAULT: "rgba(30,58,95,0.9)",
+          },
+          ring: {
+            DEFAULT: "#C8A84B",
+          },
+          content: {
+            subtle:   "#4B5563",
+            DEFAULT:  "#94A3B8",
+            emphasis: "#F1F5F9",
+            strong:   "#FFFFFF",
+            inverted: "#050D1A",
+          },
+        },
+      },
+      fontFamily: {
+        display: ["Sora", "Inter", "sans-serif"],
+        body:    ["Inter", "sans-serif"],
+      },
+      animation: {
+        shimmer: "shimmer 1.5s ease-in-out infinite",
+        float:   "float 3s ease-in-out infinite",
+      },
+      keyframes: {
+        shimmer: {
+          "0%":   { backgroundPosition: "-200% 0" },
+          "100%": { backgroundPosition:  "200% 0"  },
+        },
+        float: {
+          "0%, 100%": { transform: "translateY(0px)" },
+          "50%":      { transform: "translateY(-6px)" },
+        },
       },
     },
   },
   plugins: [],
 };
+
 export default config;

--- a/types/tailwindcss-flatten.d.ts
+++ b/types/tailwindcss-flatten.d.ts
@@ -1,0 +1,4 @@
+declare module 'tailwindcss/lib/util/flattenColorPalette' {
+  const flattenColorPalette: (colors: Record<string, unknown>) => Record<string, string>;
+  export default flattenColorPalette;
+}


### PR DESCRIPTION
## O que muda neste PR

### PR1 — Design System Base

- **`app/globals.css`** — refatorado por completo:
  - Import de fontes Sora (display) + Inter (body) via Google Fonts
  - CSS custom properties: tokens de cor, tipografia fluida (`clamp()`), espaçamento 4px, radius, sombras, transições
  - `.card` unificado (`.card-lol` agora é alias de `.card` para compatibilidade)
  - `.btn-gold` e `.btn-outline-gold` redesenhados com hover lift + glow
  - Novas classes: `.stat-pill`, `.tag-win`, `.tag-loss`, `.divider`, `.skeleton`, `.animate-float`
  - Scrollbar customizada usando tokens
  - `@media (prefers-reduced-motion: reduce)` global

- **`app/layout.tsx`** — melhorado:
  - `<link preconnect>` para Google Fonts
  - Metadata completa com `title.template`, `openGraph` e `twitter`

- **`tailwind.config.ts`** — expandido:
  - Tema Tremor configurado com paleta ArenaGG (`#C8A84B` como brand default)
  - `fontFamily.display` e `fontFamily.body` adicionados
  - Keyframes `shimmer` e `float` registrados

### PR2 — Framer Motion

**Instalação necessária após merge:**
```bash
npm install framer-motion
```

- **`components/home/HeroSection.tsx`** *(novo — Client Component)*
  - Extraído de `app/page.tsx` (Server Component)
  - Animações de entrada escalonada (título, subtítulo, CTAs)
  - Gradiente overlay melhorado com vinheta vertical

- **`components/home/StatsSection.tsx`** *(novo — Client Component)*
  - Extraído de `app/page.tsx`
  - Ícones Lucide substituem emojis (`Users`, `Shield`, `Trophy`, `Map`)
  - `staggerChildren` com `whileInView` — anima ao entrar na viewport
  - `whileHover` com lift de 4px

- **`components/home/HowItWorks.tsx`** *(novo — Client Component)*
  - Extraído de `app/page.tsx`
  - Grid assimétrico: Passo 01 ocupa `md:col-span-3` (destaque)
  - Ícones Lucide (`UserPlus`, `Shield`, `ClipboardList`, `Swords`)
  - `staggerChildren` com `whileInView`

- **`app/page.tsx`** — simplificado:
  - Server Component limpo, apenas fetches + composição dos 3 novos componentes
  - Empty state do torneio usa `.animate-float` e tokens CSS

- **`components/layout/Navbar.tsx`** — melhorado:
  - `AnimatePresence` + `motion.div` no menu mobile (slide suave com height animation)
  - Ícone hambúrguer animado com `motion.path` (morph X↔☰)
  - Logo trocado de emoji por `<Swords />` do Lucide com nome `ArenaGG`
  - Navbar agora é `sticky top-0` com `backdrop-filter: blur(12px)`

## Arquivos alterados

| Arquivo | Tipo |
|---|---|
| `app/globals.css` | Modificado |
| `app/layout.tsx` | Modificado |
| `app/page.tsx` | Modificado |
| `tailwind.config.ts` | Modificado |
| `components/home/HeroSection.tsx` | **Novo** |
| `components/home/StatsSection.tsx` | **Novo** |
| `components/home/HowItWorks.tsx` | **Novo** |
| `components/layout/Navbar.tsx` | Modificado |

## Próximos PRs

- **PR3** — Aceternity UI (`BackgroundBeams`, `CardSpotlight`, `Meteors`)
- **PR4** — Tremor (`@tremor/react`) em `PlayerStatsCard` e `ChampionStatsTable`
- **PR5** — Refactor completo da página de perfil (`components/profile/`)